### PR TITLE
fix: get_list_components strip "Tui" in query

### DIFF
--- a/src/utils/list-components.ts
+++ b/src/utils/list-components.ts
@@ -8,7 +8,7 @@ export interface ListedComponent {
     type: string | null;
 }
 
-export function constructComponentsList(query: string = ''): {
+export function constructComponentsList(query = ''): {
     items: ListedComponent[];
     normalizedQuery: string | null;
 } {


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
