### PR TITLE
feat: add init & remove CLI commands to scaffold/remove the MCP server

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,5 +14,5 @@
         "**/package.json",
         "**/tsconfig*.json"
     ],
-    "ignoreWords": ["Acpekt", "modelcontextprotocol"]
+    "ignoreWords": ["Acpekt", "modelcontextprotocol", "opencode"]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,15 @@ jobs:
       - uses: taiga-family/ci/actions/setup/node@e9c5cd341c28d9aeb357b757df41cddcbb674b2d # v1.222.0
       - run: npm run build
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: taiga-family/ci/actions/setup/variables@e9c5cd341c28d9aeb357b757df41cddcbb674b2d # v1.222.0
+      - uses: taiga-family/ci/actions/setup/node@e9c5cd341c28d9aeb357b757df41cddcbb674b2d # v1.222.0
+      - run: npm test
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Prefer a one-liner? Run `init` to write (or merge) the config into your client's
 npx @taiga-ui/mcp init --client claude # writes .mcp.json
 npx @taiga-ui/mcp init --client cursor # writes .cursor/mcp.json
 npx @taiga-ui/mcp init --client vscode # writes .vscode/mcp.json
+npx @taiga-ui/mcp init --client windsurf # writes ~/.codeium/windsurf/mcp_config.json (global only)
 npx @taiga-ui/mcp init --client opencode # writes opencode.json
 npx @taiga-ui/mcp init --client codex # writes .codex/config.toml
 ```
+
+Windsurf only reads a machine-global MCP config, so `--client windsurf` always writes
+`~/.codeium/windsurf/mcp_config.json` regardless of `--scope`.
 
 Target another docs version with `--version` — `next`, or a previous major like `v4` (defaults to `latest`):
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ npx @taiga-ui/mcp init --client cursor # writes .cursor/mcp.json
 npx @taiga-ui/mcp init --client vscode # writes .vscode/mcp.json
 ```
 
-Pass `--source-url=...` to pin a specific docs source (defaults to `https://taiga-ui.dev/llms-full.txt`).
+Target another docs version with `--version` — `next`, or a previous major like `v4` (defaults to `latest`):
+
+```bash
+npx @taiga-ui/mcp init --client cursor --version next
+npx @taiga-ui/mcp init --client cursor --version v4
+```
+
+For a fully custom source, `--source-url=...` overrides `--version`.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,14 @@ npx @taiga-ui/mcp init --client cursor --version v4
 
 For a fully custom source, `--source-url=...` overrides `--version`.
 
-Or just run `npx @taiga-ui/mcp init` with no flags to pick the client and docs version interactively.
+By default `init` writes a project-local config you can commit to the repo. Pass `--scope user` (short `-s`) to write
+your machine-global config instead — e.g. `~/.cursor/mcp.json` (defaults to `project`):
+
+```bash
+npx @taiga-ui/mcp init --client cursor --scope user # writes ~/.cursor/mcp.json
+```
+
+Or just run `npx @taiga-ui/mcp init` with no flags to pick the client, docs version, and scope interactively.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Prefer a one-liner? Run `init` to write (or merge) the config into your client's
 npx @taiga-ui/mcp init --client claude # writes .mcp.json
 npx @taiga-ui/mcp init --client cursor # writes .cursor/mcp.json
 npx @taiga-ui/mcp init --client vscode # writes .vscode/mcp.json
+npx @taiga-ui/mcp init --client opencode # writes opencode.json
+npx @taiga-ui/mcp init --client codex # writes .codex/config.toml
 ```
 
 Target another docs version with `--version` — `next`, or a previous major like `v4` (defaults to `latest`):

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ npx @taiga-ui/mcp init --client cursor --version v4
 For a fully custom source, `--source-url=...` overrides `--version`.
 
 By default `init` writes a project-local config you can commit to the repo. Pass `--scope user` (short `-s`) to write
-your machine-global config instead — e.g. `~/.cursor/mcp.json` (defaults to `project`):
+your machine-global config instead — e.g. `~/.cursor/mcp.json` (defaults to `project`). Pass both with
+`--scope project,user` (comma-separated, or repeat the flag) to write the project and global configs in one run:
 
 ```bash
 npx @taiga-ui/mcp init --client cursor --scope user # writes ~/.cursor/mcp.json
+npx @taiga-ui/mcp init --client cursor --scope project,user # writes both .cursor/mcp.json and ~/.cursor/mcp.json
 ```
 
 Or just run `npx @taiga-ui/mcp init` with no flags to pick the client, docs version, and scope interactively.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ First, install the Taiga UI MCP server with your client.
 }
 ```
 
+#### Quick install
+
+Prefer a one-liner? Run `init` to write (or merge) the config into your client's project-local file:
+
+```bash
+npx @taiga-ui/mcp init --client claude # writes .mcp.json
+npx @taiga-ui/mcp init --client cursor # writes .cursor/mcp.json
+npx @taiga-ui/mcp init --client vscode # writes .vscode/mcp.json
+```
+
+Pass `--source-url=...` to pin a specific docs source (defaults to `https://taiga-ui.dev/llms-full.txt`).
+
 ### Tools
 
 <details>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ npx @taiga-ui/mcp init --client cursor --version v4
 
 For a fully custom source, `--source-url=...` overrides `--version`.
 
+Or just run `npx @taiga-ui/mcp init` with no flags to pick the client and docs version interactively.
+
 ### Tools
 
 <details>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ npx @taiga-ui/mcp init --client cursor --scope user # writes ~/.cursor/mcp.json
 
 Or just run `npx @taiga-ui/mcp init` with no flags to pick the client, docs version, and scope interactively.
 
+#### Removing the server
+
+`remove` is the inverse of `init` — it deletes only the `taiga-ui` entry from a client config, leaving every other
+server untouched. It accepts the same `--client` and `--scope` flags (and the same interactive pickers when omitted):
+
+```bash
+npx @taiga-ui/mcp remove --client cursor # strips taiga-ui from .cursor/mcp.json
+npx @taiga-ui/mcp remove --client codex --scope user # strips it from ~/.codex/config.toml
+```
+
+If the config or the entry is missing, `remove` reports it and exits successfully.
+
 ### Tools
 
 <details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@taiga-ui/configs": "0.529.0",
                 "@types/node": "24.12.4",
                 "husky": "9.1.7",
+                "tsx": "^4.23.13",
                 "typescript": "5.9.3"
             },
             "engines": {
@@ -2483,9 +2484,9 @@
             "peer": true
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-            "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2495,15 +2496,14 @@
             "os": [
                 "aix"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-            "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
             "cpu": [
                 "arm"
             ],
@@ -2513,15 +2513,14 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-            "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
             "cpu": [
                 "arm64"
             ],
@@ -2531,15 +2530,14 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-            "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
             "cpu": [
                 "x64"
             ],
@@ -2549,15 +2547,14 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-            "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
             "cpu": [
                 "arm64"
             ],
@@ -2567,15 +2564,14 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-            "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
             "cpu": [
                 "x64"
             ],
@@ -2585,15 +2581,14 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-            "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
             "cpu": [
                 "arm64"
             ],
@@ -2603,15 +2598,14 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-            "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
             "cpu": [
                 "x64"
             ],
@@ -2621,15 +2615,14 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-            "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
             "cpu": [
                 "arm"
             ],
@@ -2639,15 +2632,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-            "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
             "cpu": [
                 "arm64"
             ],
@@ -2657,15 +2649,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-            "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2675,15 +2666,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-            "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
             "cpu": [
                 "loong64"
             ],
@@ -2693,15 +2683,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-            "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
             "cpu": [
                 "mips64el"
             ],
@@ -2711,15 +2700,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-            "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2729,15 +2717,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-            "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2747,15 +2734,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-            "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
             "cpu": [
                 "s390x"
             ],
@@ -2765,15 +2751,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-            "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
             "cpu": [
                 "x64"
             ],
@@ -2783,15 +2768,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-            "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
             "cpu": [
                 "arm64"
             ],
@@ -2801,15 +2785,14 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-            "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
             "cpu": [
                 "x64"
             ],
@@ -2819,15 +2802,14 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-            "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2837,15 +2819,14 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-            "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
             "cpu": [
                 "x64"
             ],
@@ -2855,15 +2836,14 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-            "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2873,15 +2853,14 @@
             "os": [
                 "openharmony"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-            "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
             "cpu": [
                 "x64"
             ],
@@ -2891,15 +2870,14 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-            "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2909,15 +2887,14 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-            "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
             "cpu": [
                 "ia32"
             ],
@@ -2927,15 +2904,14 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-            "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
             "cpu": [
                 "x64"
             ],
@@ -2945,7 +2921,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8832,14 +8807,12 @@
             ]
         },
         "node_modules/esbuild": {
-            "version": "0.27.4",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-            "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -8847,32 +8820,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.4",
-                "@esbuild/android-arm": "0.27.4",
-                "@esbuild/android-arm64": "0.27.4",
-                "@esbuild/android-x64": "0.27.4",
-                "@esbuild/darwin-arm64": "0.27.4",
-                "@esbuild/darwin-x64": "0.27.4",
-                "@esbuild/freebsd-arm64": "0.27.4",
-                "@esbuild/freebsd-x64": "0.27.4",
-                "@esbuild/linux-arm": "0.27.4",
-                "@esbuild/linux-arm64": "0.27.4",
-                "@esbuild/linux-ia32": "0.27.4",
-                "@esbuild/linux-loong64": "0.27.4",
-                "@esbuild/linux-mips64el": "0.27.4",
-                "@esbuild/linux-ppc64": "0.27.4",
-                "@esbuild/linux-riscv64": "0.27.4",
-                "@esbuild/linux-s390x": "0.27.4",
-                "@esbuild/linux-x64": "0.27.4",
-                "@esbuild/netbsd-arm64": "0.27.4",
-                "@esbuild/netbsd-x64": "0.27.4",
-                "@esbuild/openbsd-arm64": "0.27.4",
-                "@esbuild/openbsd-x64": "0.27.4",
-                "@esbuild/openharmony-arm64": "0.27.4",
-                "@esbuild/sunos-x64": "0.27.4",
-                "@esbuild/win32-arm64": "0.27.4",
-                "@esbuild/win32-ia32": "0.27.4",
-                "@esbuild/win32-x64": "0.27.4"
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/esbuild-wasm": {
@@ -10442,7 +10415,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -19451,6 +19423,25 @@
             "dev": true,
             "license": "0BSD",
             "peer": true
+        },
+        "node_modules/tsx": {
+            "version": "4.23.13",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+            "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.28.0"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "dist/"
     ],
     "scripts": {
-        "build": "npm run clean && tsc --incremental false && chmod 755 dist/index.js",
+        "build": "npm run clean && tsc -p tsconfig.build.json --incremental false && chmod 755 dist/index.js",
         "clean": "rm -rf dist",
         "cspell": "cspell --relative --dot --gitignore .",
         "lint": "eslint .",
@@ -50,6 +50,7 @@
         "prettier": "prettier !package-lock.json . --ignore-path .gitignore",
         "release": "npm run build && npm publish --access public --tag latest",
         "start": "node dist/index.js",
+        "test": "npm run build && tsx --test test/*.spec.ts",
         "typecheck": "tsc --noEmit --incremental false"
     },
     "commitlint": {
@@ -75,6 +76,7 @@
         "@taiga-ui/configs": "0.529.0",
         "@types/node": "24.12.4",
         "husky": "9.1.7",
+        "tsx": "^4.23.13",
         "typescript": "5.9.3"
     },
     "engines": {

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -1,0 +1,58 @@
+export interface ServerEntry {
+    readonly type?: string;
+    readonly command: string;
+    readonly args: readonly string[];
+}
+
+export interface ClientConfig {
+    readonly id: string;
+    readonly label: string;
+    readonly configPath: string;
+    readonly containerKey: string;
+    buildEntry(sourceUrl: string): ServerEntry;
+}
+
+export const SERVER_NAME = 'taiga-ui';
+
+function buildStandardEntry(sourceUrl: string): ServerEntry {
+    return {
+        command: 'npx',
+        args: ['-y', '@taiga-ui/mcp@latest', `--source-url=${sourceUrl}`],
+    };
+}
+
+function buildStdioEntry(sourceUrl: string): ServerEntry {
+    return {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@taiga-ui/mcp@latest', `--source-url=${sourceUrl}`],
+    };
+}
+
+export const CLIENTS: readonly ClientConfig[] = [
+    {
+        id: 'claude',
+        label: 'Claude Code',
+        configPath: '.mcp.json',
+        containerKey: 'mcpServers',
+        buildEntry: buildStandardEntry,
+    },
+    {
+        id: 'cursor',
+        label: 'Cursor',
+        configPath: '.cursor/mcp.json',
+        containerKey: 'mcpServers',
+        buildEntry: buildStandardEntry,
+    },
+    {
+        id: 'vscode',
+        label: 'VS Code',
+        configPath: '.vscode/mcp.json',
+        containerKey: 'servers',
+        buildEntry: buildStdioEntry,
+    },
+];
+
+export function findClient(id: string): ClientConfig | undefined {
+    return CLIENTS.find((client) => client.id === id);
+}

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -12,6 +12,7 @@ export interface JsonClientConfig {
     readonly configPath: string;
     readonly containerKey: string;
     readonly rootDefaults?: Record<string, unknown>;
+    readonly note?: string;
     buildEntry(sourceUrl: string): JsonEntry;
 }
 
@@ -21,6 +22,7 @@ export interface TomlClientConfig {
     readonly label: string;
     readonly configPath: string;
     readonly tableName: string;
+    readonly note?: string;
     buildEntry(sourceUrl: string): TomlEntry;
 }
 
@@ -97,6 +99,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         label: 'Codex',
         configPath: '.codex/config.toml',
         tableName: 'mcp_servers.taiga-ui',
+        note: 'Codex reads a project .codex/config.toml only in a trusted workspace — trust this folder in Codex, or add the server to ~/.codex/config.toml instead.',
         buildEntry: buildCommandEntry,
     },
 ];

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -5,11 +5,16 @@ export interface TomlEntry {
     readonly args: readonly string[];
 }
 
+export type UserPath =
+    | string
+    | {readonly darwin: string; readonly win32: string; readonly linux: string};
+
 export interface JsonClientConfig {
     readonly kind: 'json';
     readonly id: string;
     readonly label: string;
     readonly configPath: string;
+    readonly userPath: UserPath;
     readonly containerKey: string;
     readonly rootDefaults?: Record<string, unknown>;
     readonly note?: string;
@@ -21,6 +26,7 @@ export interface TomlClientConfig {
     readonly id: string;
     readonly label: string;
     readonly configPath: string;
+    readonly userPath: UserPath;
     readonly tableName: string;
     readonly note?: string;
     buildEntry(sourceUrl: string): TomlEntry;
@@ -65,6 +71,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         id: 'claude',
         label: 'Claude Code',
         configPath: '.mcp.json',
+        userPath: '.claude.json',
         containerKey: 'mcpServers',
         buildEntry: buildStandardEntry,
     },
@@ -73,6 +80,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         id: 'cursor',
         label: 'Cursor',
         configPath: '.cursor/mcp.json',
+        userPath: '.cursor/mcp.json',
         containerKey: 'mcpServers',
         buildEntry: buildStandardEntry,
     },
@@ -81,6 +89,11 @@ export const CLIENTS: readonly ClientConfig[] = [
         id: 'vscode',
         label: 'VS Code',
         configPath: '.vscode/mcp.json',
+        userPath: {
+            darwin: 'Library/Application Support/Code/User/mcp.json',
+            win32: 'AppData/Roaming/Code/User/mcp.json',
+            linux: '.config/Code/User/mcp.json',
+        },
         containerKey: 'servers',
         buildEntry: buildStdioEntry,
     },
@@ -89,6 +102,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         id: 'opencode',
         label: 'OpenCode',
         configPath: 'opencode.json',
+        userPath: '.config/opencode/opencode.json',
         containerKey: 'mcp',
         rootDefaults: {$schema: OPENCODE_SCHEMA},
         buildEntry: buildOpencodeEntry,
@@ -98,6 +112,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         id: 'codex',
         label: 'Codex',
         configPath: '.codex/config.toml',
+        userPath: '.codex/config.toml',
         tableName: 'mcp_servers.taiga-ui',
         note: 'Codex reads a project .codex/config.toml only in a trusted workspace — trust this folder in Codex, or add the server to ~/.codex/config.toml instead.',
         buildEntry: buildCommandEntry,

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -18,6 +18,7 @@ export interface JsonClientConfig {
     readonly containerKey: string;
     readonly rootDefaults?: Record<string, unknown>;
     readonly note?: string;
+    readonly userScopeOnly?: boolean;
     buildEntry(sourceUrl: string): JsonEntry;
 }
 
@@ -29,6 +30,7 @@ export interface TomlClientConfig {
     readonly userPath: UserPath;
     readonly tableName: string;
     readonly note?: string;
+    readonly userScopeOnly?: boolean;
     buildEntry(sourceUrl: string): TomlEntry;
 }
 
@@ -96,6 +98,16 @@ export const CLIENTS: readonly ClientConfig[] = [
         },
         containerKey: 'servers',
         buildEntry: buildStdioEntry,
+    },
+    {
+        kind: 'json',
+        id: 'windsurf',
+        label: 'Windsurf',
+        configPath: '.codeium/windsurf/mcp_config.json',
+        userPath: '.codeium/windsurf/mcp_config.json',
+        containerKey: 'mcpServers',
+        userScopeOnly: true,
+        buildEntry: buildStandardEntry,
     },
     {
         kind: 'json',

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -1,36 +1,65 @@
-export interface ServerEntry {
-    readonly type?: string;
+export type JsonEntry = Record<string, unknown>;
+
+export interface TomlEntry {
     readonly command: string;
     readonly args: readonly string[];
 }
 
-export interface ClientConfig {
+export interface JsonClientConfig {
+    readonly kind: 'json';
     readonly id: string;
     readonly label: string;
     readonly configPath: string;
     readonly containerKey: string;
-    buildEntry(sourceUrl: string): ServerEntry;
+    readonly rootDefaults?: Record<string, unknown>;
+    buildEntry(sourceUrl: string): JsonEntry;
 }
+
+export interface TomlClientConfig {
+    readonly kind: 'toml';
+    readonly id: string;
+    readonly label: string;
+    readonly configPath: string;
+    readonly tableName: string;
+    buildEntry(sourceUrl: string): TomlEntry;
+}
+
+export type ClientConfig = JsonClientConfig | TomlClientConfig;
 
 export const SERVER_NAME = 'taiga-ui';
 
-function buildStandardEntry(sourceUrl: string): ServerEntry {
+const OPENCODE_SCHEMA = 'https://opencode.ai/config.json';
+
+function commandArgs(sourceUrl: string): readonly string[] {
+    return ['-y', '@taiga-ui/mcp@latest', `--source-url=${sourceUrl}`];
+}
+
+function buildCommandEntry(sourceUrl: string): TomlEntry {
     return {
         command: 'npx',
-        args: ['-y', '@taiga-ui/mcp@latest', `--source-url=${sourceUrl}`],
+        args: commandArgs(sourceUrl),
     };
 }
 
-function buildStdioEntry(sourceUrl: string): ServerEntry {
+function buildStandardEntry(sourceUrl: string): JsonEntry {
+    return {...buildCommandEntry(sourceUrl)};
+}
+
+function buildStdioEntry(sourceUrl: string): JsonEntry {
+    return {type: 'stdio', ...buildCommandEntry(sourceUrl)};
+}
+
+function buildOpencodeEntry(sourceUrl: string): JsonEntry {
     return {
-        type: 'stdio',
-        command: 'npx',
-        args: ['-y', '@taiga-ui/mcp@latest', `--source-url=${sourceUrl}`],
+        type: 'local',
+        command: ['npx', ...commandArgs(sourceUrl)],
+        enabled: true,
     };
 }
 
 export const CLIENTS: readonly ClientConfig[] = [
     {
+        kind: 'json',
         id: 'claude',
         label: 'Claude Code',
         configPath: '.mcp.json',
@@ -38,6 +67,7 @@ export const CLIENTS: readonly ClientConfig[] = [
         buildEntry: buildStandardEntry,
     },
     {
+        kind: 'json',
         id: 'cursor',
         label: 'Cursor',
         configPath: '.cursor/mcp.json',
@@ -45,11 +75,29 @@ export const CLIENTS: readonly ClientConfig[] = [
         buildEntry: buildStandardEntry,
     },
     {
+        kind: 'json',
         id: 'vscode',
         label: 'VS Code',
         configPath: '.vscode/mcp.json',
         containerKey: 'servers',
         buildEntry: buildStdioEntry,
+    },
+    {
+        kind: 'json',
+        id: 'opencode',
+        label: 'OpenCode',
+        configPath: 'opencode.json',
+        containerKey: 'mcp',
+        rootDefaults: {$schema: OPENCODE_SCHEMA},
+        buildEntry: buildOpencodeEntry,
+    },
+    {
+        kind: 'toml',
+        id: 'codex',
+        label: 'Codex',
+        configPath: '.codex/config.toml',
+        tableName: 'mcp_servers.taiga-ui',
+        buildEntry: buildCommandEntry,
     },
 ];
 

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -1,0 +1,91 @@
+import {mkdir, readFile, writeFile} from 'node:fs/promises';
+import {dirname} from 'node:path';
+
+import {type ServerEntry} from './clients.js';
+
+export type JsonObject = Record<string, unknown>;
+
+export function parseConfig(raw: string): JsonObject {
+    if (!raw.trim()) {
+        return {};
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        throw new Error(
+            `Existing config is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error('Existing config is not a JSON object.');
+    }
+
+    return parsed as JsonObject;
+}
+
+export function mergeServerEntry(
+    config: JsonObject,
+    containerKey: string,
+    serverName: string,
+    entry: ServerEntry,
+): {merged: JsonObject; existed: boolean} {
+    const current = config[containerKey];
+
+    const container =
+        typeof current === 'object' && current !== null && !Array.isArray(current)
+            ? (current as JsonObject)
+            : {};
+
+    const existed = serverName in container;
+
+    const merged: JsonObject = {
+        ...config,
+        [containerKey]: {
+            ...container,
+            [serverName]: entry,
+        },
+    };
+
+    return {merged, existed};
+}
+
+export function serializeConfig(config: JsonObject): string {
+    return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export async function readConfigFile(filePath: string): Promise<JsonObject> {
+    let raw: string;
+
+    try {
+        raw = await readFile(filePath, 'utf8');
+    } catch (error) {
+        if (isFileNotFound(error)) {
+            return {};
+        }
+
+        throw error;
+    }
+
+    return parseConfig(raw);
+}
+
+export async function writeConfigFile(
+    filePath: string,
+    config: JsonObject,
+): Promise<void> {
+    await mkdir(dirname(filePath), {recursive: true});
+    await writeFile(filePath, serializeConfig(config), 'utf8');
+}
+
+function isFileNotFound(error: unknown): boolean {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'ENOENT'
+    );
+}

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -53,6 +53,37 @@ export function mergeServerEntry(
     return {merged, existed};
 }
 
+export function removeServerEntry(
+    config: JsonObject,
+    containerKey: string,
+    serverName: string,
+): {config: JsonObject; removed: boolean} {
+    const current = config[containerKey];
+
+    if (typeof current !== 'object' || current === null || Array.isArray(current)) {
+        return {config, removed: false};
+    }
+
+    const container = current as JsonObject;
+
+    if (!(serverName in container)) {
+        return {config, removed: false};
+    }
+
+    const nextContainer: JsonObject = {};
+
+    for (const [key, value] of Object.entries(container)) {
+        if (key !== serverName) {
+            nextContainer[key] = value;
+        }
+    }
+
+    return {
+        config: {...config, [containerKey]: nextContainer},
+        removed: true,
+    };
+}
+
 export function serializeConfig(config: JsonObject): string {
     return `${JSON.stringify(config, null, 2)}\n`;
 }

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -1,7 +1,7 @@
 import {mkdir, readFile, writeFile} from 'node:fs/promises';
 import {dirname} from 'node:path';
 
-import {type ServerEntry} from './clients.js';
+import {type JsonEntry} from './clients.js';
 
 export type JsonObject = Record<string, unknown>;
 
@@ -31,7 +31,7 @@ export function mergeServerEntry(
     config: JsonObject,
     containerKey: string,
     serverName: string,
-    entry: ServerEntry,
+    entry: JsonEntry,
 ): {merged: JsonObject; existed: boolean} {
     const current = config[containerKey];
 
@@ -81,7 +81,7 @@ export async function writeConfigFile(
     await writeFile(filePath, serializeConfig(config), 'utf8');
 }
 
-function isFileNotFound(error: unknown): boolean {
+export function isFileNotFound(error: unknown): boolean {
     return (
         typeof error === 'object' &&
         error !== null &&

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -20,7 +20,7 @@ interface InitOptions {
     readonly clients: readonly string[];
     readonly version?: string;
     readonly sourceUrl?: string;
-    readonly scope?: string;
+    readonly scopes: readonly string[];
 }
 
 export interface ResolvedClients {
@@ -28,9 +28,9 @@ export interface ResolvedClients {
     readonly unknown: readonly string[];
 }
 
-function collectClients(target: string[], value: string | undefined): void {
-    for (const id of value?.split(',') ?? []) {
-        const trimmed = id.trim();
+function collectValues(target: string[], value: string | undefined): void {
+    for (const raw of value?.split(',') ?? []) {
+        const trimmed = raw.trim();
 
         if (trimmed) {
             target.push(trimmed);
@@ -40,17 +40,17 @@ function collectClients(target: string[], value: string | undefined): void {
 
 export function parseArgs(argv: readonly string[]): InitOptions {
     const clients: string[] = [];
+    const scopes: string[] = [];
     let version: string | undefined;
     let sourceUrl: string | undefined;
-    let scope: string | undefined;
 
     for (let index = 0; index < argv.length; index++) {
         const arg = argv[index];
 
         if (arg === '--client') {
-            collectClients(clients, argv[++index]);
+            collectValues(clients, argv[++index]);
         } else if (arg?.startsWith('--client=')) {
-            collectClients(clients, arg.slice('--client='.length));
+            collectValues(clients, arg.slice('--client='.length));
         } else if (arg === '--version') {
             version = argv[++index];
         } else if (arg?.startsWith('--version=')) {
@@ -60,13 +60,13 @@ export function parseArgs(argv: readonly string[]): InitOptions {
         } else if (arg?.startsWith('--source-url=')) {
             sourceUrl = arg.slice('--source-url='.length);
         } else if (arg === '--scope' || arg === '-s') {
-            scope = argv[++index];
+            collectValues(scopes, argv[++index]);
         } else if (arg?.startsWith('--scope=')) {
-            scope = arg.slice('--scope='.length);
+            collectValues(scopes, arg.slice('--scope='.length));
         }
     }
 
-    return {clients, version, sourceUrl, scope};
+    return {clients, version, sourceUrl, scopes};
 }
 
 // latest -> site root, next / vN -> a versioned docs path; unknown -> undefined.
@@ -161,28 +161,35 @@ async function resolveVersion(
 
 // Missing --scope: ask in a terminal, otherwise default to project.
 export async function resolveScope(
-    scopeOption: string | undefined,
+    scopeOptions: readonly string[],
     title = 'Where should it live?',
     labels: readonly [string, string] = [
         'project — this repo (committable)',
         'user — global for your machine',
     ],
-): Promise<Scope> {
-    if (scopeOption !== undefined) {
-        if (scopeOption === 'project' || scopeOption === 'user') {
-            return scopeOption;
+): Promise<readonly Scope[]> {
+    if (scopeOptions.length > 0) {
+        const scopes: Scope[] = [];
+
+        for (const scope of scopeOptions) {
+            if (scope !== 'project' && scope !== 'user') {
+                fail(`Unknown scope "${scope}". Use "project" or "user".\n`);
+            }
+
+            scopes.push(scope);
         }
 
-        fail(`Unknown scope "${scopeOption}". Use "project" or "user".\n`);
+        return [...new Set(scopes)];
     }
 
     if (!isInteractive()) {
-        return 'project';
+        return ['project'];
     }
 
-    const index = await promptSelect(title, labels, 0);
+    const indices = await promptMultiSelect(title, labels);
+    const scopes = indices.map((index): Scope => (index === 1 ? 'user' : 'project'));
 
-    return index === 1 ? 'user' : 'project';
+    return [...new Set(scopes)];
 }
 
 export function fail(message: string): never {
@@ -195,7 +202,7 @@ export async function runInit(argv: string[]): Promise<void> {
         clients: clientIds,
         version: versionOption,
         sourceUrl: sourceUrlOverride,
-        scope: scopeOption,
+        scopes: scopeOptions,
     } = parseArgs(argv);
 
     const resolved = await resolveClients(clientIds);
@@ -228,32 +235,37 @@ export async function runInit(argv: string[]): Promise<void> {
         );
     }
 
-    const scope = await resolveScope(scopeOption);
+    const scopes = await resolveScope(scopeOptions);
     const env = {cwd: process.cwd(), home: homedir(), platform: process.platform};
     const summaries: string[] = [];
     const notes: string[] = [];
 
     for (const client of resolved.clients) {
-        const effectiveScope = client.userScopeOnly ? 'user' : scope;
-        const filePath = resolveConfigPath(client, effectiveScope, env);
+        const effective = [
+            ...new Set(scopes.map((scope) => (client.userScopeOnly ? 'user' : scope))),
+        ];
 
-        const existed =
-            client.kind === 'json'
-                ? await writeJsonClient(client, filePath, sourceUrl)
-                : await writeTomlClient(client, filePath, sourceUrl);
+        for (const effectiveScope of effective) {
+            const filePath = resolveConfigPath(client, effectiveScope, env);
 
-        summaries.push(
-            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${displayPath(client, effectiveScope, env)} (${client.label}).`,
-        );
+            const existed =
+                client.kind === 'json'
+                    ? await writeJsonClient(client, filePath, sourceUrl)
+                    : await writeTomlClient(client, filePath, sourceUrl);
 
-        if (client.userScopeOnly && scope === 'project') {
-            notes.push(
-                `${client.label} only has a global config, so it was written to ${displayPath(client, effectiveScope, env)} instead of the project.`,
+            summaries.push(
+                `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${displayPath(client, effectiveScope, env)} (${client.label}).`,
             );
-        }
 
-        if (client.note !== undefined && effectiveScope === 'project') {
-            notes.push(client.note);
+            if (client.userScopeOnly && scopes.includes('project')) {
+                notes.push(
+                    `${client.label} only has a global config, so it was written to ${displayPath(client, effectiveScope, env)} instead of the project.`,
+                );
+            }
+
+            if (client.note !== undefined && effectiveScope === 'project') {
+                notes.push(client.note);
+            }
         }
     }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,4 +1,4 @@
-import {resolve} from 'node:path';
+import {homedir} from 'node:os';
 
 import {
     type ClientConfig,
@@ -10,6 +10,7 @@ import {
 } from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
 import {isInteractive, promptMultiSelect, promptSelect, promptText} from './prompt.js';
+import {displayPath, resolveConfigPath, type Scope} from './scope.js';
 import {readTextFile, upsertTomlTable, writeTextFile} from './toml-file.js';
 
 const DOCS_ORIGIN = 'https://taiga-ui.dev';
@@ -19,6 +20,7 @@ interface InitOptions {
     readonly clients: readonly string[];
     readonly version?: string;
     readonly sourceUrl?: string;
+    readonly scope?: string;
 }
 
 interface ResolvedClients {
@@ -40,6 +42,7 @@ function parseArgs(argv: readonly string[]): InitOptions {
     const clients: string[] = [];
     let version: string | undefined;
     let sourceUrl: string | undefined;
+    let scope: string | undefined;
 
     for (let index = 0; index < argv.length; index++) {
         const arg = argv[index];
@@ -56,10 +59,14 @@ function parseArgs(argv: readonly string[]): InitOptions {
             sourceUrl = argv[++index];
         } else if (arg?.startsWith('--source-url=')) {
             sourceUrl = arg.slice('--source-url='.length);
+        } else if (arg === '--scope' || arg === '-s') {
+            scope = argv[++index];
+        } else if (arg?.startsWith('--scope=')) {
+            scope = arg.slice('--scope='.length);
         }
     }
 
-    return {clients, version, sourceUrl};
+    return {clients, version, sourceUrl, scope};
 }
 
 // latest -> site root, next / vN -> a versioned docs path; unknown -> undefined.
@@ -151,6 +158,29 @@ async function resolveVersion(
         : (await promptText('Which major? (e.g. v4)')) || DEFAULT_VERSION;
 }
 
+// Missing --scope: ask in a terminal, otherwise default to project.
+async function resolveScope(scopeOption: string | undefined): Promise<Scope> {
+    if (scopeOption !== undefined) {
+        if (scopeOption === 'project' || scopeOption === 'user') {
+            return scopeOption;
+        }
+
+        fail(`Unknown scope "${scopeOption}". Use "project" or "user".\n`);
+    }
+
+    if (!isInteractive()) {
+        return 'project';
+    }
+
+    const index = await promptSelect(
+        'Where should it live?',
+        ['project — this repo (committable)', 'user — global for your machine'],
+        0,
+    );
+
+    return index === 1 ? 'user' : 'project';
+}
+
 function fail(message: string): never {
     process.stderr.write(message);
     process.exit(1);
@@ -161,6 +191,7 @@ export async function runInit(argv: string[]): Promise<void> {
         clients: clientIds,
         version: versionOption,
         sourceUrl: sourceUrlOverride,
+        scope: scopeOption,
     } = parseArgs(argv);
 
     const resolved = await resolveClients(clientIds);
@@ -193,10 +224,12 @@ export async function runInit(argv: string[]): Promise<void> {
         );
     }
 
+    const scope = await resolveScope(scopeOption);
+    const env = {cwd: process.cwd(), home: homedir(), platform: process.platform};
     const summaries: string[] = [];
 
     for (const client of resolved.clients) {
-        const filePath = resolve(process.cwd(), client.configPath);
+        const filePath = resolveConfigPath(client, scope, env);
 
         const existed =
             client.kind === 'json'
@@ -204,20 +237,23 @@ export async function runInit(argv: string[]): Promise<void> {
                 : await writeTomlClient(client, filePath, sourceUrl);
 
         summaries.push(
-            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${client.configPath} (${client.label}).`,
+            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${displayPath(client, scope, env)} (${client.label}).`,
         );
     }
 
     const restart =
         resolved.clients.length === 1 ? resolved.clients[0]?.label : 'your clients';
 
-    const notes = [
-        ...new Set(
-            resolved.clients
-                .map((client) => client.note)
-                .filter((note): note is string => note !== undefined),
-        ),
-    ];
+    const notes =
+        scope === 'project'
+            ? [
+                  ...new Set(
+                      resolved.clients
+                          .map((client) => client.note)
+                          .filter((note): note is string => note !== undefined),
+                  ),
+              ]
+            : [];
 
     const noteLines = notes.map((note) => `Note: ${note}\n`).join('');
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,20 +9,35 @@ import {
     type TomlClientConfig,
 } from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
-import {isInteractive, promptMenu, promptText} from './prompt.js';
+import {isInteractive, promptMultiSelect, promptSelect, promptText} from './prompt.js';
 import {readTextFile, upsertTomlTable, writeTextFile} from './toml-file.js';
 
 const DOCS_ORIGIN = 'https://taiga-ui.dev';
 const DEFAULT_VERSION = 'latest';
 
 interface InitOptions {
-    readonly client?: string;
+    readonly clients: readonly string[];
     readonly version?: string;
     readonly sourceUrl?: string;
 }
 
+interface ResolvedClients {
+    readonly clients: readonly ClientConfig[];
+    readonly unknown: readonly string[];
+}
+
+function collectClients(target: string[], value: string | undefined): void {
+    for (const id of value?.split(',') ?? []) {
+        const trimmed = id.trim();
+
+        if (trimmed) {
+            target.push(trimmed);
+        }
+    }
+}
+
 function parseArgs(argv: readonly string[]): InitOptions {
-    let client: string | undefined;
+    const clients: string[] = [];
     let version: string | undefined;
     let sourceUrl: string | undefined;
 
@@ -30,9 +45,9 @@ function parseArgs(argv: readonly string[]): InitOptions {
         const arg = argv[index];
 
         if (arg === '--client') {
-            client = argv[++index];
+            collectClients(clients, argv[++index]);
         } else if (arg?.startsWith('--client=')) {
-            client = arg.slice('--client='.length);
+            collectClients(clients, arg.slice('--client='.length));
         } else if (arg === '--version') {
             version = argv[++index];
         } else if (arg?.startsWith('--version=')) {
@@ -44,7 +59,7 @@ function parseArgs(argv: readonly string[]): InitOptions {
         }
     }
 
-    return {client, version, sourceUrl};
+    return {clients, version, sourceUrl};
 }
 
 // latest -> site root, next / vN -> a versioned docs path; unknown -> undefined.
@@ -63,21 +78,41 @@ function supportedClientsMessage(): string {
 }
 
 // Missing --client: pick from a menu in a terminal, otherwise leave undefined for the error path.
-async function resolveClient(clientId?: string): Promise<ClientConfig | undefined> {
-    if (clientId) {
-        return findClient(clientId);
+async function resolveClients(
+    ids: readonly string[],
+): Promise<ResolvedClients | undefined> {
+    if (ids.length > 0) {
+        const clients: ClientConfig[] = [];
+        const unknown: string[] = [];
+
+        for (const id of ids) {
+            const client = findClient(id);
+
+            if (client) {
+                clients.push(client);
+            } else {
+                unknown.push(id);
+            }
+        }
+
+        return {clients, unknown};
     }
 
     if (!isInteractive()) {
         return undefined;
     }
 
-    const index = await promptMenu(
-        'Which MCP client?',
+    const indices = await promptMultiSelect(
+        'Which MCP client(s)?',
         CLIENTS.map((client) => client.label),
     );
 
-    return CLIENTS[index];
+    return {
+        clients: indices
+            .map((index) => CLIENTS[index])
+            .filter((client): client is ClientConfig => client !== undefined),
+        unknown: [],
+    };
 }
 
 // Missing --version (and no --source-url): ask in a terminal, otherwise default to latest.
@@ -97,7 +132,7 @@ async function resolveVersion(
         return DEFAULT_VERSION;
     }
 
-    const index = await promptMenu(
+    const index = await promptSelect(
         'Docs version',
         [
             'latest (current stable)',
@@ -116,49 +151,70 @@ async function resolveVersion(
         : (await promptText('Which major? (e.g. v4)')) || DEFAULT_VERSION;
 }
 
+function fail(message: string): never {
+    process.stderr.write(message);
+    process.exit(1);
+}
+
 export async function runInit(argv: string[]): Promise<void> {
     const {
-        client: clientId,
+        clients: clientIds,
         version: versionOption,
         sourceUrl: sourceUrlOverride,
     } = parseArgs(argv);
 
-    const client = await resolveClient(clientId);
+    const resolved = await resolveClients(clientIds);
 
-    if (!client) {
-        const reason = clientId
-            ? `Unknown client "${clientId}".`
-            : 'Missing --client option.';
-
-        process.stderr.write(
-            `${reason}\nSupported clients:\n${supportedClientsMessage()}\n`,
+    if (!resolved) {
+        fail(
+            `Missing --client option.\nSupported clients:\n${supportedClientsMessage()}\n`,
         );
-        process.exit(1);
+    }
+
+    if (resolved.unknown.length > 0) {
+        fail(
+            `Unknown client "${resolved.unknown.join('", "')}".\n` +
+                `Supported clients:\n${supportedClientsMessage()}\n`,
+        );
+    }
+
+    if (resolved.clients.length === 0) {
+        fail(
+            `Missing --client option.\nSupported clients:\n${supportedClientsMessage()}\n`,
+        );
     }
 
     const version = await resolveVersion(versionOption, sourceUrlOverride);
     const sourceUrl = sourceUrlOverride ?? resolveSourceUrl(version);
 
     if (!sourceUrl) {
-        process.stderr.write(
+        fail(
             `Unknown version "${version}". Use "latest", "next", or a major like "v4".\n`,
         );
-        process.exit(1);
     }
 
-    const filePath = resolve(process.cwd(), client.configPath);
+    const summaries: string[] = [];
 
-    const existed =
-        client.kind === 'json'
-            ? await writeJsonClient(client, filePath, sourceUrl)
-            : await writeTomlClient(client, filePath, sourceUrl);
+    for (const client of resolved.clients) {
+        const filePath = resolve(process.cwd(), client.configPath);
 
-    const action = existed ? 'Updated' : 'Added';
+        const existed =
+            client.kind === 'json'
+                ? await writeJsonClient(client, filePath, sourceUrl)
+                : await writeTomlClient(client, filePath, sourceUrl);
+
+        summaries.push(
+            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${client.configPath} (${client.label}).`,
+        );
+    }
+
+    const restart =
+        resolved.clients.length === 1 ? resolved.clients[0]?.label : 'your clients';
 
     process.stdout.write(
-        `${action} "${SERVER_NAME}" MCP server in ${client.configPath} (${client.label}).\n` +
+        `${summaries.join('\n')}\n` +
             `Source: ${sourceUrl}\n` +
-            `Next: restart ${client.label} to load the Taiga UI MCP server.\n`,
+            `Next: restart ${restart} to load the Taiga UI MCP server.\n`,
     );
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,14 @@
 import {resolve} from 'node:path';
 
-import {CLIENTS, findClient, SERVER_NAME} from './clients.js';
+import {
+    CLIENTS,
+    findClient,
+    type JsonClientConfig,
+    SERVER_NAME,
+    type TomlClientConfig,
+} from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
+import {readTextFile, upsertTomlTable, writeTextFile} from './toml-file.js';
 
 const DOCS_ORIGIN = 'https://taiga-ui.dev';
 const DEFAULT_VERSION = 'latest';
@@ -84,17 +91,11 @@ export async function runInit(argv: string[]): Promise<void> {
     }
 
     const filePath = resolve(process.cwd(), client.configPath);
-    const config = await readConfigFile(filePath);
-    const entry = client.buildEntry(sourceUrl);
 
-    const {merged, existed} = mergeServerEntry(
-        config,
-        client.containerKey,
-        SERVER_NAME,
-        entry,
-    );
-
-    await writeConfigFile(filePath, merged);
+    const existed =
+        client.kind === 'json'
+            ? await writeJsonClient(client, filePath, sourceUrl)
+            : await writeTomlClient(client, filePath, sourceUrl);
 
     const action = existed ? 'Updated' : 'Added';
 
@@ -103,4 +104,39 @@ export async function runInit(argv: string[]): Promise<void> {
             `Source: ${sourceUrl}\n` +
             `Next: restart ${client.label} to load the Taiga UI MCP server.\n`,
     );
+}
+
+async function writeJsonClient(
+    client: JsonClientConfig,
+    filePath: string,
+    sourceUrl: string,
+): Promise<boolean> {
+    const config = await readConfigFile(filePath);
+    const base = client.rootDefaults ? {...client.rootDefaults, ...config} : config;
+    const entry = client.buildEntry(sourceUrl);
+
+    const {merged, existed} = mergeServerEntry(
+        base,
+        client.containerKey,
+        SERVER_NAME,
+        entry,
+    );
+
+    await writeConfigFile(filePath, merged);
+
+    return existed;
+}
+
+async function writeTomlClient(
+    client: TomlClientConfig,
+    filePath: string,
+    sourceUrl: string,
+): Promise<boolean> {
+    const existing = await readTextFile(filePath);
+    const entry = client.buildEntry(sourceUrl);
+    const {content, existed} = upsertTomlTable(existing, client.tableName, entry);
+
+    await writeTextFile(filePath, content);
+
+    return existed;
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,73 @@
+import {resolve} from 'node:path';
+
+import {CLIENTS, findClient, SERVER_NAME} from './clients.js';
+import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
+
+const DEFAULT_SOURCE_URL = 'https://taiga-ui.dev/llms-full.txt';
+
+interface InitOptions {
+    readonly client?: string;
+    readonly sourceUrl: string;
+}
+
+function parseArgs(argv: readonly string[]): InitOptions {
+    let client: string | undefined;
+    let sourceUrl = DEFAULT_SOURCE_URL;
+
+    for (let index = 0; index < argv.length; index++) {
+        const arg = argv[index];
+
+        if (arg === '--client') {
+            client = argv[++index];
+        } else if (arg?.startsWith('--client=')) {
+            client = arg.slice('--client='.length);
+        } else if (arg === '--source-url') {
+            sourceUrl = argv[++index] ?? sourceUrl;
+        } else if (arg?.startsWith('--source-url=')) {
+            sourceUrl = arg.slice('--source-url='.length);
+        }
+    }
+
+    return {client, sourceUrl};
+}
+
+function supportedClientsMessage(): string {
+    return CLIENTS.map((client) => `  - ${client.id} (${client.label})`).join('\n');
+}
+
+export async function runInit(argv: string[]): Promise<void> {
+    const {client: clientId, sourceUrl} = parseArgs(argv);
+    const client = clientId ? findClient(clientId) : undefined;
+
+    if (!client) {
+        const reason = clientId
+            ? `Unknown client "${clientId}".`
+            : 'Missing --client option.';
+
+        process.stderr.write(
+            `${reason}\nSupported clients:\n${supportedClientsMessage()}\n`,
+        );
+        process.exit(1);
+    }
+
+    const filePath = resolve(process.cwd(), client.configPath);
+    const config = await readConfigFile(filePath);
+    const entry = client.buildEntry(sourceUrl);
+
+    const {merged, existed} = mergeServerEntry(
+        config,
+        client.containerKey,
+        SERVER_NAME,
+        entry,
+    );
+
+    await writeConfigFile(filePath, merged);
+
+    const action = existed ? 'Updated' : 'Added';
+
+    process.stdout.write(
+        `${action} "${SERVER_NAME}" MCP server in ${client.configPath} (${client.label}).\n` +
+            `Source: ${sourceUrl}\n` +
+            `Next: restart ${client.label} to load the Taiga UI MCP server.\n`,
+    );
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -211,10 +211,20 @@ export async function runInit(argv: string[]): Promise<void> {
     const restart =
         resolved.clients.length === 1 ? resolved.clients[0]?.label : 'your clients';
 
+    const notes = [
+        ...new Set(
+            resolved.clients
+                .map((client) => client.note)
+                .filter((note): note is string => note !== undefined),
+        ),
+    ];
+
+    const noteLines = notes.map((note) => `Note: ${note}\n`).join('');
+
     process.stdout.write(
         `${summaries.join('\n')}\n` +
             `Source: ${sourceUrl}\n` +
-            `Next: restart ${restart} to load the Taiga UI MCP server.\n`,
+            `Next: restart ${restart} to load the Taiga UI MCP server.\n${noteLines}`,
     );
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,7 +9,7 @@ import {
     type TomlClientConfig,
 } from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
-import {isInteractive, promptMultiSelect, promptSelect, promptText} from './prompt.js';
+import {isInteractive, promptMultiSelect, promptSelect} from './prompt.js';
 import {displayPath, resolveConfigPath, type Scope} from './scope.js';
 import {readTextFile, upsertTomlTable, writeTextFile} from './toml-file.js';
 
@@ -140,23 +140,9 @@ async function resolveVersion(
         return DEFAULT_VERSION;
     }
 
-    const index = await promptSelect(
-        'Docs version',
-        [
-            'latest (current stable)',
-            'next (upcoming major)',
-            'other (a previous major, e.g. v4)',
-        ],
-        0,
-    );
+    const index = await promptSelect('Docs version', ['v5 (latest)', 'v4'], 0);
 
-    if (index === 0) {
-        return 'latest';
-    }
-
-    return index === 1
-        ? 'next'
-        : (await promptText('Which major? (e.g. v4)')) || DEFAULT_VERSION;
+    return index === 0 ? 'latest' : 'v4';
 }
 
 // Missing --scope: ask in a terminal, otherwise default to project.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -23,7 +23,7 @@ interface InitOptions {
     readonly scope?: string;
 }
 
-interface ResolvedClients {
+export interface ResolvedClients {
     readonly clients: readonly ClientConfig[];
     readonly unknown: readonly string[];
 }
@@ -38,7 +38,7 @@ function collectClients(target: string[], value: string | undefined): void {
     }
 }
 
-function parseArgs(argv: readonly string[]): InitOptions {
+export function parseArgs(argv: readonly string[]): InitOptions {
     const clients: string[] = [];
     let version: string | undefined;
     let sourceUrl: string | undefined;
@@ -80,12 +80,12 @@ export function resolveSourceUrl(version: string): string | undefined {
         : undefined;
 }
 
-function supportedClientsMessage(): string {
+export function supportedClientsMessage(): string {
     return CLIENTS.map((client) => `  - ${client.id} (${client.label})`).join('\n');
 }
 
 // Missing --client: pick from a menu in a terminal, otherwise leave undefined for the error path.
-async function resolveClients(
+export async function resolveClients(
     ids: readonly string[],
 ): Promise<ResolvedClients | undefined> {
     if (ids.length > 0) {
@@ -159,7 +159,7 @@ async function resolveVersion(
 }
 
 // Missing --scope: ask in a terminal, otherwise default to project.
-async function resolveScope(scopeOption: string | undefined): Promise<Scope> {
+export async function resolveScope(scopeOption: string | undefined): Promise<Scope> {
     if (scopeOption !== undefined) {
         if (scopeOption === 'project' || scopeOption === 'user') {
             return scopeOption;
@@ -181,7 +181,7 @@ async function resolveScope(scopeOption: string | undefined): Promise<Scope> {
     return index === 1 ? 'user' : 'project';
 }
 
-function fail(message: string): never {
+export function fail(message: string): never {
     process.stderr.write(message);
     process.exit(1);
 }
@@ -227,9 +227,11 @@ export async function runInit(argv: string[]): Promise<void> {
     const scope = await resolveScope(scopeOption);
     const env = {cwd: process.cwd(), home: homedir(), platform: process.platform};
     const summaries: string[] = [];
+    const notes: string[] = [];
 
     for (const client of resolved.clients) {
-        const filePath = resolveConfigPath(client, scope, env);
+        const effectiveScope = client.userScopeOnly ? 'user' : scope;
+        const filePath = resolveConfigPath(client, effectiveScope, env);
 
         const existed =
             client.kind === 'json'
@@ -237,25 +239,24 @@ export async function runInit(argv: string[]): Promise<void> {
                 : await writeTomlClient(client, filePath, sourceUrl);
 
         summaries.push(
-            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${displayPath(client, scope, env)} (${client.label}).`,
+            `${existed ? 'Updated' : 'Added'} "${SERVER_NAME}" MCP server in ${displayPath(client, effectiveScope, env)} (${client.label}).`,
         );
+
+        if (client.userScopeOnly && scope === 'project') {
+            notes.push(
+                `${client.label} only has a global config, so it was written to ${displayPath(client, effectiveScope, env)} instead of the project.`,
+            );
+        }
+
+        if (client.note !== undefined && effectiveScope === 'project') {
+            notes.push(client.note);
+        }
     }
 
     const restart =
         resolved.clients.length === 1 ? resolved.clients[0]?.label : 'your clients';
 
-    const notes =
-        scope === 'project'
-            ? [
-                  ...new Set(
-                      resolved.clients
-                          .map((client) => client.note)
-                          .filter((note): note is string => note !== undefined),
-                  ),
-              ]
-            : [];
-
-    const noteLines = notes.map((note) => `Note: ${note}\n`).join('');
+    const noteLines = [...new Set(notes)].map((note) => `Note: ${note}\n`).join('');
 
     process.stdout.write(
         `${summaries.join('\n')}\n` +

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,16 +3,19 @@ import {resolve} from 'node:path';
 import {CLIENTS, findClient, SERVER_NAME} from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
 
-const DEFAULT_SOURCE_URL = 'https://taiga-ui.dev/llms-full.txt';
+const DOCS_ORIGIN = 'https://taiga-ui.dev';
+const DEFAULT_VERSION = 'latest';
 
 interface InitOptions {
     readonly client?: string;
-    readonly sourceUrl: string;
+    readonly version?: string;
+    readonly sourceUrl?: string;
 }
 
 function parseArgs(argv: readonly string[]): InitOptions {
     let client: string | undefined;
-    let sourceUrl = DEFAULT_SOURCE_URL;
+    let version: string | undefined;
+    let sourceUrl: string | undefined;
 
     for (let index = 0; index < argv.length; index++) {
         const arg = argv[index];
@@ -21,14 +24,29 @@ function parseArgs(argv: readonly string[]): InitOptions {
             client = argv[++index];
         } else if (arg?.startsWith('--client=')) {
             client = arg.slice('--client='.length);
+        } else if (arg === '--version') {
+            version = argv[++index];
+        } else if (arg?.startsWith('--version=')) {
+            version = arg.slice('--version='.length);
         } else if (arg === '--source-url') {
-            sourceUrl = argv[++index] ?? sourceUrl;
+            sourceUrl = argv[++index];
         } else if (arg?.startsWith('--source-url=')) {
             sourceUrl = arg.slice('--source-url='.length);
         }
     }
 
-    return {client, sourceUrl};
+    return {client, version, sourceUrl};
+}
+
+// latest -> site root, next / vN -> a versioned docs path; unknown -> undefined.
+export function resolveSourceUrl(version: string): string | undefined {
+    if (version === 'latest') {
+        return `${DOCS_ORIGIN}/llms-full.txt`;
+    }
+
+    return version === 'next' || /^v\d+$/.test(version)
+        ? `${DOCS_ORIGIN}/${version}/llms-full.txt`
+        : undefined;
 }
 
 function supportedClientsMessage(): string {
@@ -36,7 +54,12 @@ function supportedClientsMessage(): string {
 }
 
 export async function runInit(argv: string[]): Promise<void> {
-    const {client: clientId, sourceUrl} = parseArgs(argv);
+    const {
+        client: clientId,
+        version: versionOption,
+        sourceUrl: sourceUrlOverride,
+    } = parseArgs(argv);
+
     const client = clientId ? findClient(clientId) : undefined;
 
     if (!client) {
@@ -46,6 +69,16 @@ export async function runInit(argv: string[]): Promise<void> {
 
         process.stderr.write(
             `${reason}\nSupported clients:\n${supportedClientsMessage()}\n`,
+        );
+        process.exit(1);
+    }
+
+    const version = versionOption ?? DEFAULT_VERSION;
+    const sourceUrl = sourceUrlOverride ?? resolveSourceUrl(version);
+
+    if (!sourceUrl) {
+        process.stderr.write(
+            `Unknown version "${version}". Use "latest", "next", or a major like "v4".\n`,
         );
         process.exit(1);
     }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,7 @@
 import {resolve} from 'node:path';
 
 import {
+    type ClientConfig,
     CLIENTS,
     findClient,
     type JsonClientConfig,
@@ -8,6 +9,7 @@ import {
     type TomlClientConfig,
 } from './clients.js';
 import {mergeServerEntry, readConfigFile, writeConfigFile} from './config-file.js';
+import {isInteractive, promptMenu, promptText} from './prompt.js';
 import {readTextFile, upsertTomlTable, writeTextFile} from './toml-file.js';
 
 const DOCS_ORIGIN = 'https://taiga-ui.dev';
@@ -60,6 +62,60 @@ function supportedClientsMessage(): string {
     return CLIENTS.map((client) => `  - ${client.id} (${client.label})`).join('\n');
 }
 
+// Missing --client: pick from a menu in a terminal, otherwise leave undefined for the error path.
+async function resolveClient(clientId?: string): Promise<ClientConfig | undefined> {
+    if (clientId) {
+        return findClient(clientId);
+    }
+
+    if (!isInteractive()) {
+        return undefined;
+    }
+
+    const index = await promptMenu(
+        'Which MCP client?',
+        CLIENTS.map((client) => client.label),
+    );
+
+    return CLIENTS[index];
+}
+
+// Missing --version (and no --source-url): ask in a terminal, otherwise default to latest.
+async function resolveVersion(
+    versionOption: string | undefined,
+    sourceUrlOverride: string | undefined,
+): Promise<string> {
+    if (sourceUrlOverride) {
+        return DEFAULT_VERSION;
+    }
+
+    if (versionOption) {
+        return versionOption;
+    }
+
+    if (!isInteractive()) {
+        return DEFAULT_VERSION;
+    }
+
+    const index = await promptMenu(
+        'Docs version',
+        [
+            'latest (current stable)',
+            'next (upcoming major)',
+            'other (a previous major, e.g. v4)',
+        ],
+        0,
+    );
+
+    if (index === 0) {
+        return 'latest';
+    }
+
+    return index === 1
+        ? 'next'
+        : (await promptText('Which major? (e.g. v4)')) || DEFAULT_VERSION;
+}
+
 export async function runInit(argv: string[]): Promise<void> {
     const {
         client: clientId,
@@ -67,7 +123,7 @@ export async function runInit(argv: string[]): Promise<void> {
         sourceUrl: sourceUrlOverride,
     } = parseArgs(argv);
 
-    const client = clientId ? findClient(clientId) : undefined;
+    const client = await resolveClient(clientId);
 
     if (!client) {
         const reason = clientId
@@ -80,7 +136,7 @@ export async function runInit(argv: string[]): Promise<void> {
         process.exit(1);
     }
 
-    const version = versionOption ?? DEFAULT_VERSION;
+    const version = await resolveVersion(versionOption, sourceUrlOverride);
     const sourceUrl = sourceUrlOverride ?? resolveSourceUrl(version);
 
     if (!sourceUrl) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -87,6 +87,7 @@ export function supportedClientsMessage(): string {
 // Missing --client: pick from a menu in a terminal, otherwise leave undefined for the error path.
 export async function resolveClients(
     ids: readonly string[],
+    title = 'Which MCP client(s)?',
 ): Promise<ResolvedClients | undefined> {
     if (ids.length > 0) {
         const clients: ClientConfig[] = [];
@@ -110,7 +111,7 @@ export async function resolveClients(
     }
 
     const indices = await promptMultiSelect(
-        'Which MCP client(s)?',
+        title,
         CLIENTS.map((client) => client.label),
     );
 
@@ -159,7 +160,14 @@ async function resolveVersion(
 }
 
 // Missing --scope: ask in a terminal, otherwise default to project.
-export async function resolveScope(scopeOption: string | undefined): Promise<Scope> {
+export async function resolveScope(
+    scopeOption: string | undefined,
+    title = 'Where should it live?',
+    labels: readonly [string, string] = [
+        'project — this repo (committable)',
+        'user — global for your machine',
+    ],
+): Promise<Scope> {
     if (scopeOption !== undefined) {
         if (scopeOption === 'project' || scopeOption === 'user') {
             return scopeOption;
@@ -172,11 +180,7 @@ export async function resolveScope(scopeOption: string | undefined): Promise<Sco
         return 'project';
     }
 
-    const index = await promptSelect(
-        'Where should it live?',
-        ['project — this repo (committable)', 'user — global for your machine'],
-        0,
-    );
+    const index = await promptSelect(title, labels, 0);
 
     return index === 1 ? 'user' : 'project';
 }

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,10 +1,28 @@
+import {clearScreenDown, cursorTo, emitKeypressEvents, moveCursor} from 'node:readline';
 import {createInterface} from 'node:readline/promises';
 import {type Readable, type Writable} from 'node:stream';
 
-export interface PromptIo {
-    readonly input: Readable;
-    readonly output: Writable;
+interface InteractiveInput extends Readable {
+    isTTY?: boolean;
+    setRawMode?(mode: boolean): void;
 }
+
+interface InteractiveOutput extends Writable {
+    isTTY?: boolean;
+}
+
+export interface PromptIo {
+    readonly input: InteractiveInput;
+    readonly output: InteractiveOutput;
+}
+
+interface Key {
+    readonly name?: string;
+    readonly ctrl?: boolean;
+}
+
+const HIDE_CURSOR = '[?25l';
+const SHOW_CURSOR = '[?25h';
 
 function processIo(): PromptIo {
     return {input: process.stdin, output: process.stdout};
@@ -15,50 +33,23 @@ export function isInteractive(): boolean {
     return process.stdin.isTTY;
 }
 
-// Returns the chosen 0-based index, the default on empty input, or null when invalid.
-export function parseMenuChoice(
-    answer: string,
-    count: number,
-    defaultIndex?: number,
-): number | null {
-    const trimmed = answer.trim();
-
-    if (!trimmed && defaultIndex !== undefined) {
-        return defaultIndex;
-    }
-
-    const choice = Number(trimmed);
-
-    return Number.isInteger(choice) && choice >= 1 && choice <= count ? choice - 1 : null;
-}
-
-export async function promptMenu(
+export async function promptSelect(
     title: string,
     labels: readonly string[],
-    defaultIndex?: number,
+    defaultIndex = 0,
     io: PromptIo = processIo(),
 ): Promise<number> {
-    const rl = createInterface({input: io.input, output: io.output});
-    const menu = labels.map((label, index) => `  ${index + 1}) ${label}`).join('\n');
-    const hint = defaultIndex === undefined ? '' : ` [${defaultIndex + 1}]`;
+    const [index] = await interactiveMenu(title, labels, false, defaultIndex, io);
 
-    try {
-        let choice: number | null = null;
+    return index ?? defaultIndex;
+}
 
-        while (choice === null) {
-            const answer = await rl.question(`${title}\n${menu}\n>${hint} `);
-
-            choice = parseMenuChoice(answer, labels.length, defaultIndex);
-
-            if (choice === null) {
-                io.output.write('Please enter a number from the list.\n');
-            }
-        }
-
-        return choice;
-    } finally {
-        rl.close();
-    }
+export async function promptMultiSelect(
+    title: string,
+    labels: readonly string[],
+    io: PromptIo = processIo(),
+): Promise<readonly number[]> {
+    return interactiveMenu(title, labels, true, 0, io);
 }
 
 export async function promptText(
@@ -72,4 +63,139 @@ export async function promptText(
     } finally {
         rl.close();
     }
+}
+
+async function interactiveMenu(
+    title: string,
+    labels: readonly string[],
+    multiple: boolean,
+    initialCursor: number,
+    io: PromptIo,
+): Promise<number[]> {
+    const {input, output} = io;
+
+    const paint =
+        output.isTTY === true ? color : (_code: string, text: string): string => text;
+
+    const selected = new Set<number>();
+    let cursor = Math.min(Math.max(initialCursor, 0), labels.length - 1);
+
+    emitKeypressEvents(input);
+
+    const rawCapable = input.isTTY === true && typeof input.setRawMode === 'function';
+
+    if (rawCapable) {
+        input.setRawMode?.(true);
+    }
+
+    const hint = multiple
+        ? '↑/↓ move · space toggle · enter confirm'
+        : '↑/↓ move · enter select';
+
+    const draw = (): void => {
+        const rows = labels.map((label, index) => {
+            const active = index === cursor;
+            const pointer = active ? paint('36', '❯') : ' ';
+
+            const box = multiple
+                ? `${selected.has(index) ? paint('32', '[·]') : '[ ]'} `
+                : '';
+
+            const text = active ? paint('1;36', label) : label;
+
+            return `${pointer} ${box}${text}`;
+        });
+
+        output.write(`${title} ${paint('2', `(${hint})`)}\n${rows.join('\n')}\n`);
+    };
+
+    const clear = (): void => {
+        moveCursor(output, 0, -(labels.length + 1));
+        cursorTo(output, 0);
+        clearScreenDown(output);
+    };
+
+    output.write(HIDE_CURSOR);
+    draw();
+
+    return new Promise<number[]>((resolve, reject) => {
+        function onKeypress(_str: string, key: Key): void {
+            if (key.ctrl && key.name === 'c') {
+                finish(null);
+
+                return;
+            }
+
+            switch (key.name) {
+                case 'down':
+                case 'j':
+                    cursor = (cursor + 1) % labels.length;
+                    redraw();
+                    break;
+                case 'enter':
+                case 'return':
+                    confirm();
+                    break;
+                case 'k':
+                case 'up':
+                    cursor = (cursor - 1 + labels.length) % labels.length;
+                    redraw();
+                    break;
+                case 'space':
+                    if (multiple) {
+                        toggle();
+                        redraw();
+                    }
+
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        function toggle(): void {
+            if (selected.has(cursor)) {
+                selected.delete(cursor);
+            } else {
+                selected.add(cursor);
+            }
+        }
+
+        function confirm(): void {
+            if (multiple && selected.size === 0) {
+                selected.add(cursor);
+            }
+
+            finish(multiple ? [...selected].sort((a, b) => a - b) : [cursor]);
+        }
+
+        function redraw(): void {
+            clear();
+            draw();
+        }
+
+        function finish(result: number[] | null): void {
+            input.off('keypress', onKeypress);
+
+            if (rawCapable) {
+                input.setRawMode?.(false);
+            }
+
+            output.write(`${SHOW_CURSOR}\n`);
+            input.pause();
+
+            if (result) {
+                resolve(result);
+            } else {
+                reject(new Error('Cancelled.'));
+            }
+        }
+
+        input.on('keypress', onKeypress);
+        input.resume();
+    });
+}
+
+function color(code: string, text: string): string {
+    return `[${code}m${text}[0m`;
 }

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,75 @@
+import {createInterface} from 'node:readline/promises';
+import {type Readable, type Writable} from 'node:stream';
+
+export interface PromptIo {
+    readonly input: Readable;
+    readonly output: Writable;
+}
+
+function processIo(): PromptIo {
+    return {input: process.stdin, output: process.stdout};
+}
+
+export function isInteractive(): boolean {
+    // isTTY is `true` on a terminal and `undefined` (falsy) otherwise.
+    return process.stdin.isTTY;
+}
+
+// Returns the chosen 0-based index, the default on empty input, or null when invalid.
+export function parseMenuChoice(
+    answer: string,
+    count: number,
+    defaultIndex?: number,
+): number | null {
+    const trimmed = answer.trim();
+
+    if (!trimmed && defaultIndex !== undefined) {
+        return defaultIndex;
+    }
+
+    const choice = Number(trimmed);
+
+    return Number.isInteger(choice) && choice >= 1 && choice <= count ? choice - 1 : null;
+}
+
+export async function promptMenu(
+    title: string,
+    labels: readonly string[],
+    defaultIndex?: number,
+    io: PromptIo = processIo(),
+): Promise<number> {
+    const rl = createInterface({input: io.input, output: io.output});
+    const menu = labels.map((label, index) => `  ${index + 1}) ${label}`).join('\n');
+    const hint = defaultIndex === undefined ? '' : ` [${defaultIndex + 1}]`;
+
+    try {
+        let choice: number | null = null;
+
+        while (choice === null) {
+            const answer = await rl.question(`${title}\n${menu}\n>${hint} `);
+
+            choice = parseMenuChoice(answer, labels.length, defaultIndex);
+
+            if (choice === null) {
+                io.output.write('Please enter a number from the list.\n');
+            }
+        }
+
+        return choice;
+    } finally {
+        rl.close();
+    }
+}
+
+export async function promptText(
+    question: string,
+    io: PromptIo = processIo(),
+): Promise<string> {
+    const rl = createInterface({input: io.input, output: io.output});
+
+    try {
+        return (await rl.question(`${question} `)).trim();
+    } finally {
+        rl.close();
+    }
+}

--- a/src/cli/remove.ts
+++ b/src/cli/remove.ts
@@ -14,7 +14,7 @@ import {readTextFile, removeTomlTable, writeTextFile} from './toml-file.js';
 
 export async function runRemove(argv: string[]): Promise<void> {
     const {clients: clientIds, scope: scopeOption} = parseArgs(argv);
-    const resolved = await resolveClients(clientIds);
+    const resolved = await resolveClients(clientIds, 'Remove from which client(s)?');
 
     if (!resolved) {
         fail(
@@ -35,7 +35,10 @@ export async function runRemove(argv: string[]): Promise<void> {
         );
     }
 
-    const scope = await resolveScope(scopeOption);
+    const scope = await resolveScope(scopeOption, 'Which scope to remove from?', [
+        'project — this repo',
+        'user — global for your machine',
+    ]);
 
     const env: ScopeEnv = {
         cwd: process.cwd(),

--- a/src/cli/remove.ts
+++ b/src/cli/remove.ts
@@ -1,0 +1,99 @@
+import {homedir} from 'node:os';
+
+import {type JsonClientConfig, SERVER_NAME, type TomlClientConfig} from './clients.js';
+import {readConfigFile, removeServerEntry, writeConfigFile} from './config-file.js';
+import {
+    fail,
+    parseArgs,
+    resolveClients,
+    resolveScope,
+    supportedClientsMessage,
+} from './init.js';
+import {displayPath, resolveConfigPath, type ScopeEnv} from './scope.js';
+import {readTextFile, removeTomlTable, writeTextFile} from './toml-file.js';
+
+export async function runRemove(argv: string[]): Promise<void> {
+    const {clients: clientIds, scope: scopeOption} = parseArgs(argv);
+    const resolved = await resolveClients(clientIds);
+
+    if (!resolved) {
+        fail(
+            `Missing --client option.\nSupported clients:\n${supportedClientsMessage()}\n`,
+        );
+    }
+
+    if (resolved.unknown.length > 0) {
+        fail(
+            `Unknown client "${resolved.unknown.join('", "')}".\n` +
+                `Supported clients:\n${supportedClientsMessage()}\n`,
+        );
+    }
+
+    if (resolved.clients.length === 0) {
+        fail(
+            `Missing --client option.\nSupported clients:\n${supportedClientsMessage()}\n`,
+        );
+    }
+
+    const scope = await resolveScope(scopeOption);
+
+    const env: ScopeEnv = {
+        cwd: process.cwd(),
+        home: homedir(),
+        platform: process.platform,
+    };
+
+    const lines: string[] = [];
+
+    for (const client of resolved.clients) {
+        const effectiveScope = client.userScopeOnly ? 'user' : scope;
+        const filePath = resolveConfigPath(client, effectiveScope, env);
+        const where = `${displayPath(client, effectiveScope, env)} (${client.label})`;
+
+        const removed =
+            client.kind === 'json'
+                ? await removeFromJsonClient(client, filePath)
+                : await removeFromTomlClient(client, filePath);
+
+        lines.push(
+            removed
+                ? `Removed "${SERVER_NAME}" from ${where}.`
+                : `No "${SERVER_NAME}" server in ${where}.`,
+        );
+    }
+
+    process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+async function removeFromJsonClient(
+    client: JsonClientConfig,
+    filePath: string,
+): Promise<boolean> {
+    const config = await readConfigFile(filePath);
+
+    const {config: next, removed} = removeServerEntry(
+        config,
+        client.containerKey,
+        SERVER_NAME,
+    );
+
+    if (removed) {
+        await writeConfigFile(filePath, next);
+    }
+
+    return removed;
+}
+
+async function removeFromTomlClient(
+    client: TomlClientConfig,
+    filePath: string,
+): Promise<boolean> {
+    const existing = await readTextFile(filePath);
+    const {content, removed} = removeTomlTable(existing, client.tableName);
+
+    if (removed) {
+        await writeTextFile(filePath, content);
+    }
+
+    return removed;
+}

--- a/src/cli/remove.ts
+++ b/src/cli/remove.ts
@@ -13,7 +13,7 @@ import {displayPath, resolveConfigPath, type ScopeEnv} from './scope.js';
 import {readTextFile, removeTomlTable, writeTextFile} from './toml-file.js';
 
 export async function runRemove(argv: string[]): Promise<void> {
-    const {clients: clientIds, scope: scopeOption} = parseArgs(argv);
+    const {clients: clientIds, scopes: scopeOptions} = parseArgs(argv);
     const resolved = await resolveClients(clientIds, 'Remove from which client(s)?');
 
     if (!resolved) {
@@ -35,7 +35,7 @@ export async function runRemove(argv: string[]): Promise<void> {
         );
     }
 
-    const scope = await resolveScope(scopeOption, 'Which scope to remove from?', [
+    const scopes = await resolveScope(scopeOptions, 'Which scope to remove from?', [
         'project — this repo',
         'user — global for your machine',
     ]);
@@ -49,20 +49,25 @@ export async function runRemove(argv: string[]): Promise<void> {
     const lines: string[] = [];
 
     for (const client of resolved.clients) {
-        const effectiveScope = client.userScopeOnly ? 'user' : scope;
-        const filePath = resolveConfigPath(client, effectiveScope, env);
-        const where = `${displayPath(client, effectiveScope, env)} (${client.label})`;
+        const effective = [
+            ...new Set(scopes.map((scope) => (client.userScopeOnly ? 'user' : scope))),
+        ];
 
-        const removed =
-            client.kind === 'json'
-                ? await removeFromJsonClient(client, filePath)
-                : await removeFromTomlClient(client, filePath);
+        for (const effectiveScope of effective) {
+            const filePath = resolveConfigPath(client, effectiveScope, env);
+            const where = `${displayPath(client, effectiveScope, env)} (${client.label})`;
 
-        lines.push(
-            removed
-                ? `Removed "${SERVER_NAME}" from ${where}.`
-                : `No "${SERVER_NAME}" server in ${where}.`,
-        );
+            const removed =
+                client.kind === 'json'
+                    ? await removeFromJsonClient(client, filePath)
+                    : await removeFromTomlClient(client, filePath);
+
+            lines.push(
+                removed
+                    ? `Removed "${SERVER_NAME}" from ${where}.`
+                    : `No "${SERVER_NAME}" server in ${where}.`,
+            );
+        }
     }
 
     process.stdout.write(`${lines.join('\n')}\n`);

--- a/src/cli/scope.ts
+++ b/src/cli/scope.ts
@@ -1,0 +1,42 @@
+import {join} from 'node:path';
+
+import {type ClientConfig, type UserPath} from './clients.js';
+
+export type Scope = 'project' | 'user';
+
+export interface ScopeEnv {
+    readonly cwd: string;
+    readonly home: string;
+    readonly platform: NodeJS.Platform;
+}
+
+// Unlisted platforms (aix, freebsd, ...) fall back to the linux path.
+function userRelativePath(userPath: UserPath, platform: NodeJS.Platform): string {
+    if (typeof userPath === 'string') {
+        return userPath;
+    }
+
+    const byPlatform: Partial<Record<NodeJS.Platform, string>> = {
+        darwin: userPath.darwin,
+        win32: userPath.win32,
+        linux: userPath.linux,
+    };
+
+    return byPlatform[platform] ?? userPath.linux;
+}
+
+export function resolveConfigPath(
+    client: ClientConfig,
+    scope: Scope,
+    env: ScopeEnv,
+): string {
+    return scope === 'user'
+        ? join(env.home, userRelativePath(client.userPath, env.platform))
+        : join(env.cwd, client.configPath);
+}
+
+export function displayPath(client: ClientConfig, scope: Scope, env: ScopeEnv): string {
+    return scope === 'user'
+        ? `~/${userRelativePath(client.userPath, env.platform)}`
+        : client.configPath;
+}

--- a/src/cli/toml-file.ts
+++ b/src/cli/toml-file.ts
@@ -1,0 +1,69 @@
+import {mkdir, readFile, writeFile} from 'node:fs/promises';
+import {dirname} from 'node:path';
+
+import {type TomlEntry} from './clients.js';
+import {isFileNotFound} from './config-file.js';
+
+export function buildTomlTable(tableName: string, entry: TomlEntry): string {
+    const args = entry.args.map((arg) => JSON.stringify(arg)).join(', ');
+
+    return [
+        `[${tableName}]`,
+        `command = ${JSON.stringify(entry.command)}`,
+        `args = [${args}]`,
+    ].join('\n');
+}
+
+export function upsertTomlTable(
+    existing: string,
+    tableName: string,
+    entry: TomlEntry,
+): {content: string; existed: boolean} {
+    const block = buildTomlTable(tableName, entry);
+    const header = `[${tableName}]`;
+    const lines = existing.split('\n');
+    const headerIndex = lines.findIndex((line) => line.trim() === header);
+
+    if (headerIndex === -1) {
+        const trimmed = existing.trimEnd();
+        const content = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
+
+        return {content, existed: false};
+    }
+
+    let endIndex = lines.length;
+
+    for (let index = headerIndex + 1; index < lines.length; index++) {
+        if (lines[index]?.trim().startsWith('[')) {
+            endIndex = index;
+            break;
+        }
+    }
+
+    const rebuilt = [
+        ...lines.slice(0, headerIndex),
+        ...block.split('\n'),
+        ...lines.slice(endIndex),
+    ].join('\n');
+
+    const content = rebuilt.endsWith('\n') ? rebuilt : `${rebuilt}\n`;
+
+    return {content, existed: true};
+}
+
+export async function readTextFile(filePath: string): Promise<string> {
+    try {
+        return await readFile(filePath, 'utf8');
+    } catch (error) {
+        if (isFileNotFound(error)) {
+            return '';
+        }
+
+        throw error;
+    }
+}
+
+export async function writeTextFile(filePath: string, content: string): Promise<void> {
+    await mkdir(dirname(filePath), {recursive: true});
+    await writeFile(filePath, content, 'utf8');
+}

--- a/src/cli/toml-file.ts
+++ b/src/cli/toml-file.ts
@@ -51,6 +51,35 @@ export function upsertTomlTable(
     return {content, existed: true};
 }
 
+export function removeTomlTable(
+    content: string,
+    tableName: string,
+): {content: string; removed: boolean} {
+    const header = `[${tableName}]`;
+    const lines = content.split('\n');
+    const headerIndex = lines.findIndex((line) => line.trim() === header);
+
+    if (headerIndex === -1) {
+        return {content, removed: false};
+    }
+
+    let endIndex = lines.length;
+
+    for (let index = headerIndex + 1; index < lines.length; index++) {
+        if (lines[index]?.trim().startsWith('[')) {
+            endIndex = index;
+            break;
+        }
+    }
+
+    const rebuilt = [...lines.slice(0, headerIndex), ...lines.slice(endIndex)].join('\n');
+
+    const normalized =
+        rebuilt === '' || rebuilt.endsWith('\n') ? rebuilt : `${rebuilt}\n`;
+
+    return {content: normalized, removed: true};
+}
+
 export async function readTextFile(filePath: string): Promise<string> {
     try {
         return await readFile(filePath, 'utf8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,14 @@ async function main(): Promise<void> {
     if (process.argv[2] === 'init') {
         const {runInit} = await import('./cli/init.js');
 
-        await runInit(process.argv.slice(3));
+        try {
+            await runInit(process.argv.slice(3));
+        } catch (error) {
+            process.stderr.write(
+                `init failed: ${error instanceof Error ? error.message : String(error)}\n`,
+            );
+            process.exit(1);
+        }
 
         return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,21 @@ async function main(): Promise<void> {
         return;
     }
 
+    if (process.argv[2] === 'remove') {
+        const {runRemove} = await import('./cli/remove.js');
+
+        try {
+            await runRemove(process.argv.slice(3));
+        } catch (error) {
+            process.stderr.write(
+                `remove failed: ${error instanceof Error ? error.message : String(error)}\n`,
+            );
+            process.exit(1);
+        }
+
+        return;
+    }
+
     const {start} = await import('./server/server.js');
 
     await start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
-import {start} from './server/server.js';
 import {logError} from './utils/logger.js';
 
-start().catch((err: unknown) => {
+async function main(): Promise<void> {
+    if (process.argv[2] === 'init') {
+        const {runInit} = await import('./cli/init.js');
+
+        await runInit(process.argv.slice(3));
+
+        return;
+    }
+
+    const {start} = await import('./server/server.js');
+
+    await start();
+}
+
+main().catch((err: unknown) => {
     logError('Unhandled startup error', err);
 
     process.exit(1);

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -14,6 +14,7 @@ describe('client registry', () => {
             const client = findClient(id);
 
             assert.ok(client);
+            assert.ok(client.kind === 'json');
             assert.equal(client.containerKey, 'mcpServers');
 
             const entry = client.buildEntry('URL');
@@ -31,14 +32,56 @@ describe('client registry', () => {
         const client = findClient('vscode');
 
         assert.ok(client);
+        assert.ok(client.kind === 'json');
         assert.equal(client.containerKey, 'servers');
         assert.equal(client.buildEntry('URL').type, 'stdio');
+    });
+
+    it('uses mcp, a local array entry, and a $schema default for opencode', () => {
+        const client = findClient('opencode');
+
+        assert.ok(client);
+        assert.ok(client.kind === 'json');
+        assert.equal(client.containerKey, 'mcp');
+        assert.deepEqual(client.rootDefaults, {
+            $schema: 'https://opencode.ai/config.json',
+        });
+
+        const entry = client.buildEntry('URL');
+
+        assert.equal(entry.type, 'local');
+        assert.equal(entry.enabled, true);
+        assert.deepEqual(entry.command, [
+            'npx',
+            '-y',
+            '@taiga-ui/mcp@latest',
+            '--source-url=URL',
+        ]);
+    });
+
+    it('uses a toml table and a command/args entry for codex', () => {
+        const client = findClient('codex');
+
+        assert.ok(client);
+        assert.ok(client.kind === 'toml');
+        assert.equal(client.tableName, 'mcp_servers.taiga-ui');
+
+        const entry = client.buildEntry('URL');
+
+        assert.equal(entry.command, 'npx');
+        assert.deepEqual(entry.args, ['-y', '@taiga-ui/mcp@latest', '--source-url=URL']);
     });
 
     it('targets project-local config paths', () => {
         assert.deepEqual(
             CLIENTS.map((client) => client.configPath),
-            ['.mcp.json', '.cursor/mcp.json', '.vscode/mcp.json'],
+            [
+                '.mcp.json',
+                '.cursor/mcp.json',
+                '.vscode/mcp.json',
+                'opencode.json',
+                '.codex/config.toml',
+            ],
         );
     });
 });

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -59,6 +59,20 @@ describe('client registry', () => {
         ]);
     });
 
+    it('uses mcpServers, a standard entry, and user-only scope for windsurf', () => {
+        const client = findClient('windsurf');
+
+        assert.ok(client);
+        assert.ok(client.kind === 'json');
+        assert.equal(client.containerKey, 'mcpServers');
+        assert.equal(client.userScopeOnly, true);
+
+        const entry = client.buildEntry('URL');
+
+        assert.equal(entry.type, undefined);
+        assert.deepEqual(entry.args, ['-y', '@taiga-ui/mcp@latest', '--source-url=URL']);
+    });
+
     it('uses a toml table and a command/args entry for codex', () => {
         const client = findClient('codex');
 
@@ -79,6 +93,7 @@ describe('client registry', () => {
                 '.mcp.json',
                 '.cursor/mcp.json',
                 '.vscode/mcp.json',
+                '.codeium/windsurf/mcp_config.json',
                 'opencode.json',
                 '.codex/config.toml',
             ],

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {CLIENTS, findClient} from '../src/cli/clients.js';
+
+describe('client registry', () => {
+    it('resolves known clients and rejects unknown ones', () => {
+        assert.equal(findClient('cursor')?.id, 'cursor');
+        assert.equal(findClient('nope'), undefined);
+    });
+
+    it('uses mcpServers and a plain entry for claude and cursor', () => {
+        for (const id of ['claude', 'cursor']) {
+            const client = findClient(id);
+
+            assert.ok(client);
+            assert.equal(client.containerKey, 'mcpServers');
+
+            const entry = client.buildEntry('URL');
+
+            assert.equal(entry.type, undefined);
+            assert.deepEqual(entry.args, [
+                '-y',
+                '@taiga-ui/mcp@latest',
+                '--source-url=URL',
+            ]);
+        }
+    });
+
+    it('uses servers and a stdio entry for vscode', () => {
+        const client = findClient('vscode');
+
+        assert.ok(client);
+        assert.equal(client.containerKey, 'servers');
+        assert.equal(client.buildEntry('URL').type, 'stdio');
+    });
+
+    it('targets project-local config paths', () => {
+        assert.deepEqual(
+            CLIENTS.map((client) => client.configPath),
+            ['.mcp.json', '.cursor/mcp.json', '.vscode/mcp.json'],
+        );
+    });
+});

--- a/test/config-file.spec.ts
+++ b/test/config-file.spec.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
 
-import {mergeServerEntry, parseConfig, serializeConfig} from '../src/cli/config-file.js';
+import {
+    mergeServerEntry,
+    parseConfig,
+    removeServerEntry,
+    serializeConfig,
+} from '../src/cli/config-file.js';
 
 const ENTRY = {command: 'npx', args: ['-y']} as const;
 
@@ -66,6 +71,66 @@ describe('mergeServerEntry', () => {
         );
 
         assert.deepEqual(merged, {mcpServers: {'taiga-ui': ENTRY}});
+    });
+});
+
+describe('removeServerEntry', () => {
+    it('removes our entry and preserves siblings and top-level keys', () => {
+        const config = {
+            other: true,
+            mcpServers: {keep: {command: 'x', args: []}, 'taiga-ui': ENTRY},
+        };
+
+        const {config: next, removed} = removeServerEntry(
+            config,
+            'mcpServers',
+            'taiga-ui',
+        );
+
+        assert.equal(removed, true);
+        assert.deepEqual(next, {
+            other: true,
+            mcpServers: {keep: {command: 'x', args: []}},
+        });
+    });
+
+    it('reports removed=false when the entry is absent', () => {
+        const {config, removed} = removeServerEntry(
+            {mcpServers: {keep: {command: 'x', args: []}}},
+            'mcpServers',
+            'taiga-ui',
+        );
+
+        assert.equal(removed, false);
+        assert.deepEqual(config, {mcpServers: {keep: {command: 'x', args: []}}});
+    });
+
+    it('reports removed=false when the container is missing or not an object', () => {
+        assert.equal(removeServerEntry({}, 'mcpServers', 'taiga-ui').removed, false);
+        assert.equal(
+            removeServerEntry({mcpServers: 5}, 'mcpServers', 'taiga-ui').removed,
+            false,
+        );
+    });
+
+    it('keeps a now-empty container intact', () => {
+        const {config, removed} = removeServerEntry(
+            {mcpServers: {'taiga-ui': ENTRY}},
+            'mcpServers',
+            'taiga-ui',
+        );
+
+        assert.equal(removed, true);
+        assert.deepEqual(config, {mcpServers: {}});
+    });
+
+    it('does not mutate the input config', () => {
+        const config = {mcpServers: {'taiga-ui': ENTRY, keep: {command: 'x', args: []}}};
+
+        removeServerEntry(config, 'mcpServers', 'taiga-ui');
+        assert.deepEqual(config, {
+            mcpServers: {'taiga-ui': ENTRY, keep: {command: 'x', args: []}},
+        });
     });
 });
 

--- a/test/config-file.spec.ts
+++ b/test/config-file.spec.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {mergeServerEntry, parseConfig, serializeConfig} from '../src/cli/config-file.js';
+
+const ENTRY = {command: 'npx', args: ['-y']} as const;
+
+describe('parseConfig', () => {
+    it('treats blank input as an empty object', () => {
+        assert.deepEqual(parseConfig(''), {});
+        assert.deepEqual(parseConfig('   \n'), {});
+    });
+
+    it('parses a JSON object', () => {
+        assert.deepEqual(parseConfig('{"a":1}'), {a: 1});
+    });
+
+    it('throws on invalid JSON', () => {
+        assert.throws(() => parseConfig('not json{'), /not valid JSON/);
+    });
+
+    it('throws on non-object JSON', () => {
+        assert.throws(() => parseConfig('[]'), /not a JSON object/);
+        assert.throws(() => parseConfig('42'), /not a JSON object/);
+    });
+});
+
+describe('mergeServerEntry', () => {
+    it('adds the server under a fresh container', () => {
+        const {merged, existed} = mergeServerEntry({}, 'mcpServers', 'taiga-ui', ENTRY);
+
+        assert.equal(existed, false);
+        assert.deepEqual(merged, {mcpServers: {'taiga-ui': ENTRY}});
+    });
+
+    it('preserves other servers and top-level keys', () => {
+        const config = {other: true, mcpServers: {keep: {command: 'x', args: []}}};
+        const {merged} = mergeServerEntry(config, 'mcpServers', 'taiga-ui', ENTRY);
+
+        assert.deepEqual(merged, {
+            other: true,
+            mcpServers: {keep: {command: 'x', args: []}, 'taiga-ui': ENTRY},
+        });
+    });
+
+    it('reports existed=true when overwriting an entry', () => {
+        const config = {mcpServers: {'taiga-ui': {command: 'old', args: []}}};
+        const {existed} = mergeServerEntry(config, 'mcpServers', 'taiga-ui', ENTRY);
+
+        assert.equal(existed, true);
+    });
+
+    it('does not mutate the input config', () => {
+        const config = {mcpServers: {keep: {command: 'x', args: []}}};
+
+        mergeServerEntry(config, 'mcpServers', 'taiga-ui', ENTRY);
+        assert.deepEqual(config, {mcpServers: {keep: {command: 'x', args: []}}});
+    });
+
+    it('replaces a non-object container instead of crashing', () => {
+        const {merged} = mergeServerEntry(
+            {mcpServers: 5},
+            'mcpServers',
+            'taiga-ui',
+            ENTRY,
+        );
+
+        assert.deepEqual(merged, {mcpServers: {'taiga-ui': ENTRY}});
+    });
+});
+
+describe('serializeConfig', () => {
+    it('pretty-prints with a trailing newline', () => {
+        assert.equal(serializeConfig({a: 1}), '{\n  "a": 1\n}\n');
+    });
+});

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+const CLI = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+
+interface McpConfig {
+    readonly mcpServers?: Record<string, {command: string; args: string[]}>;
+    readonly servers?: Record<string, {type?: string; command: string; args: string[]}>;
+}
+
+function runInit(
+    cwd: string,
+    args: readonly string[],
+): {status: number | null; stderr: string} {
+    const result = spawnSync('node', [CLI, 'init', ...args], {cwd, encoding: 'utf8'});
+
+    return {status: result.status, stderr: result.stderr};
+}
+
+function readConfig(path: string): McpConfig {
+    return JSON.parse(readFileSync(path, 'utf8')) as McpConfig;
+}
+
+describe('init command (built CLI)', () => {
+    let dir = '';
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'tui-mcp-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, {recursive: true, force: true});
+    });
+
+    it('scaffolds cursor config with the default source url', () => {
+        const {status} = runInit(dir, ['--client', 'cursor']);
+
+        assert.equal(status, 0);
+        assert.deepEqual(readConfig(join(dir, '.cursor/mcp.json')), {
+            mcpServers: {
+                'taiga-ui': {
+                    command: 'npx',
+                    args: [
+                        '-y',
+                        '@taiga-ui/mcp@latest',
+                        '--source-url=https://taiga-ui.dev/llms-full.txt',
+                    ],
+                },
+            },
+        });
+    });
+
+    it('writes servers and a stdio entry for vscode', () => {
+        runInit(dir, ['--client', 'vscode']);
+
+        const config = readConfig(join(dir, '.vscode/mcp.json'));
+
+        assert.equal(config.servers?.['taiga-ui']?.type, 'stdio');
+    });
+
+    it('preserves an existing unrelated server and honors --source-url', () => {
+        mkdirSync(join(dir, '.cursor'));
+        writeFileSync(
+            join(dir, '.cursor/mcp.json'),
+            '{"mcpServers":{"other":{"command":"x","args":[]}}}',
+        );
+
+        runInit(dir, ['--client', 'cursor', '--source-url=https://example.com/x']);
+
+        const config = readConfig(join(dir, '.cursor/mcp.json'));
+        const taiga = config.mcpServers?.['taiga-ui'];
+
+        assert.ok(config.mcpServers?.other);
+        assert.ok(taiga);
+        assert.equal(
+            taiga.args[taiga.args.length - 1],
+            '--source-url=https://example.com/x',
+        );
+    });
+
+    it('exits non-zero and lists clients for an unknown client', () => {
+        const {status, stderr} = runInit(dir, ['--client', 'foo']);
+
+        assert.equal(status, 1);
+        assert.match(stderr, /Unknown client/);
+        assert.match(stderr, /cursor/);
+    });
+
+    it('does not clobber an existing invalid config', () => {
+        mkdirSync(join(dir, '.vscode'));
+        writeFileSync(join(dir, '.vscode/mcp.json'), 'not json{');
+
+        const {status} = runInit(dir, ['--client', 'vscode']);
+
+        assert.notEqual(status, 0);
+        assert.equal(readFileSync(join(dir, '.vscode/mcp.json'), 'utf8'), 'not json{');
+    });
+});

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -28,6 +28,19 @@ function readConfig(path: string): McpConfig {
     return JSON.parse(readFileSync(path, 'utf8')) as McpConfig;
 }
 
+interface OpencodeConfig {
+    readonly $schema?: string;
+    readonly mcp?: Record<string, {type?: string; command?: string[]; enabled?: boolean}>;
+}
+
+function readOpencode(path: string): OpencodeConfig {
+    return JSON.parse(readFileSync(path, 'utf8')) as OpencodeConfig;
+}
+
+function readText(path: string): string {
+    return readFileSync(path, 'utf8');
+}
+
 describe('init command (built CLI)', () => {
     let dir = '';
 
@@ -144,6 +157,95 @@ describe('init command (built CLI)', () => {
 
         assert.equal(status, 1);
         assert.match(stderr, /Unknown version/);
+    });
+
+    it('scaffolds opencode.json with a local array entry and $schema', () => {
+        const {status} = runInit(dir, ['--client', 'opencode']);
+
+        assert.equal(status, 0);
+        assert.deepEqual(readOpencode(join(dir, 'opencode.json')), {
+            $schema: 'https://opencode.ai/config.json',
+            mcp: {
+                'taiga-ui': {
+                    type: 'local',
+                    command: [
+                        'npx',
+                        '-y',
+                        '@taiga-ui/mcp@latest',
+                        '--source-url=https://taiga-ui.dev/llms-full.txt',
+                    ],
+                    enabled: true,
+                },
+            },
+        });
+    });
+
+    it('preserves other opencode servers and does not overwrite an existing $schema', () => {
+        writeFileSync(
+            join(dir, 'opencode.json'),
+            JSON.stringify({$schema: 'custom', mcp: {other: {type: 'local'}}}),
+        );
+
+        runInit(dir, ['--client', 'opencode']);
+
+        const config = readOpencode(join(dir, 'opencode.json'));
+
+        assert.equal(config.$schema, 'custom');
+        assert.ok(config.mcp?.other);
+        assert.ok(config.mcp['taiga-ui']);
+    });
+
+    it('reflects --version next in the opencode command array', () => {
+        runInit(dir, ['--client', 'opencode', '--version', 'next']);
+
+        const command = readOpencode(join(dir, 'opencode.json')).mcp?.['taiga-ui']
+            ?.command;
+
+        assert.ok(command);
+        assert.equal(
+            command[command.length - 1],
+            '--source-url=https://taiga-ui.dev/next/llms-full.txt',
+        );
+    });
+
+    it('scaffolds .codex/config.toml with the table', () => {
+        const {status} = runInit(dir, ['--client', 'codex']);
+
+        assert.equal(status, 0);
+        assert.equal(
+            readText(join(dir, '.codex/config.toml')),
+            [
+                '[mcp_servers.taiga-ui]',
+                'command = "npx"',
+                'args = ["-y", "@taiga-ui/mcp@latest", "--source-url=https://taiga-ui.dev/llms-full.txt"]',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('preserves other codex tables and never duplicates ours on re-run', () => {
+        mkdirSync(join(dir, '.codex'));
+        writeFileSync(
+            join(dir, '.codex/config.toml'),
+            '[mcp_servers.other]\ncommand = "y"\nargs = []\n',
+        );
+
+        runInit(dir, ['--client', 'codex']);
+        runInit(dir, ['--client', 'codex']);
+
+        const toml = readText(join(dir, '.codex/config.toml'));
+
+        assert.match(toml, /\[mcp_servers\.other\]/);
+        assert.equal(toml.match(/\[mcp_servers\.taiga-ui\]/g)?.length, 1);
+    });
+
+    it('reflects --version v4 in the codex args', () => {
+        runInit(dir, ['--client', 'codex', '--version', 'v4']);
+
+        assert.match(
+            readText(join(dir, '.codex/config.toml')),
+            /--source-url=https:\/\/taiga-ui\.dev\/v4\/llms-full\.txt/,
+        );
     });
 });
 

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -122,6 +122,7 @@ describe('init command (built CLI)', () => {
         assert.equal(status, 1);
         assert.match(stderr, /Unknown client/);
         assert.match(stderr, /cursor/);
+        assert.match(stderr, /windsurf/);
     });
 
     it('does not clobber an existing invalid config', () => {
@@ -348,6 +349,31 @@ describe('init command --scope (built CLI)', () => {
 
         assert.match(project.stdout, /trust this folder in Codex/);
         assert.doesNotMatch(user.stdout, /trust this folder in Codex/);
+    });
+
+    it('writes a user-scope windsurf config under HOME', () => {
+        const {status} = run(['--client', 'windsurf', '--scope', 'user']);
+
+        assert.equal(status, 0);
+        assert.ok(
+            readConfig(join(home, '.codeium/windsurf/mcp_config.json')).mcpServers?.[
+                'taiga-ui'
+            ],
+        );
+    });
+
+    it('forces windsurf to the global config even for project scope', () => {
+        const {status, stdout} = run(['--client', 'windsurf']);
+
+        assert.equal(status, 0);
+        assert.ok(
+            readConfig(join(home, '.codeium/windsurf/mcp_config.json')).mcpServers?.[
+                'taiga-ui'
+            ],
+        );
+        assert.equal(existsSync(join(dir, '.codeium/windsurf/mcp_config.json')), false);
+        assert.match(stdout, /global config/);
+        assert.match(stdout, /~\/\.codeium\/windsurf\/mcp_config\.json/);
     });
 });
 

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -97,9 +97,10 @@ describe('init command (built CLI)', () => {
         mkdirSync(join(dir, '.vscode'));
         writeFileSync(join(dir, '.vscode/mcp.json'), 'not json{');
 
-        const {status} = runInit(dir, ['--client', 'vscode']);
+        const {status, stderr} = runInit(dir, ['--client', 'vscode']);
 
         assert.notEqual(status, 0);
+        assert.match(stderr, /init failed/);
         assert.equal(readFileSync(join(dir, '.vscode/mcp.json'), 'utf8'), 'not json{');
     });
 

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -6,6 +6,8 @@ import {join} from 'node:path';
 import {afterEach, beforeEach, describe, it} from 'node:test';
 import {fileURLToPath} from 'node:url';
 
+import {resolveSourceUrl} from '../src/cli/init.js';
+
 const CLI = fileURLToPath(new URL('../dist/index.js', import.meta.url));
 
 interface McpConfig {
@@ -99,5 +101,64 @@ describe('init command (built CLI)', () => {
 
         assert.notEqual(status, 0);
         assert.equal(readFileSync(join(dir, '.vscode/mcp.json'), 'utf8'), 'not json{');
+    });
+
+    it('resolves --version next to the next docs url', () => {
+        runInit(dir, ['--client', 'cursor', '--version', 'next']);
+
+        const taiga = readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui'];
+
+        assert.ok(taiga);
+        assert.equal(
+            taiga.args[taiga.args.length - 1],
+            '--source-url=https://taiga-ui.dev/next/llms-full.txt',
+        );
+    });
+
+    it('lets --source-url override --version', () => {
+        runInit(dir, [
+            '--client',
+            'cursor',
+            '--version',
+            'next',
+            '--source-url=https://example.com/x',
+        ]);
+
+        const taiga = readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui'];
+
+        assert.ok(taiga);
+        assert.equal(
+            taiga.args[taiga.args.length - 1],
+            '--source-url=https://example.com/x',
+        );
+    });
+
+    it('exits non-zero for an unknown version', () => {
+        const {status, stderr} = runInit(dir, [
+            '--client',
+            'cursor',
+            '--version',
+            'bogus',
+        ]);
+
+        assert.equal(status, 1);
+        assert.match(stderr, /Unknown version/);
+    });
+});
+
+describe('resolveSourceUrl', () => {
+    it('maps latest to the site root', () => {
+        assert.equal(resolveSourceUrl('latest'), 'https://taiga-ui.dev/llms-full.txt');
+    });
+
+    it('maps next and majors to their versioned path', () => {
+        assert.equal(resolveSourceUrl('next'), 'https://taiga-ui.dev/next/llms-full.txt');
+        assert.equal(resolveSourceUrl('v4'), 'https://taiga-ui.dev/v4/llms-full.txt');
+        assert.equal(resolveSourceUrl('v12'), 'https://taiga-ui.dev/v12/llms-full.txt');
+    });
+
+    it('returns undefined for an unknown version', () => {
+        assert.equal(resolveSourceUrl('bogus'), undefined);
+        assert.equal(resolveSourceUrl('v'), undefined);
     });
 });

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -78,6 +78,17 @@ describe('init command (built CLI)', () => {
         assert.equal(config.servers?.['taiga-ui']?.type, 'stdio');
     });
 
+    it('scaffolds several clients from a comma-separated --client', () => {
+        const {status} = runInit(dir, ['--client', 'cursor,codex']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+        assert.match(
+            readText(join(dir, '.codex/config.toml')),
+            /\[mcp_servers\.taiga-ui\]/,
+        );
+    });
+
     it('preserves an existing unrelated server and honors --source-url', () => {
         mkdirSync(join(dir, '.cursor'));
         writeFileSync(

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import {spawnSync} from 'node:child_process';
-import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterEach, beforeEach, describe, it} from 'node:test';
@@ -266,6 +273,81 @@ describe('init command (built CLI)', () => {
             readText(join(dir, '.codex/config.toml')),
             /--source-url=https:\/\/taiga-ui\.dev\/v4\/llms-full\.txt/,
         );
+    });
+});
+
+describe('init command --scope (built CLI)', () => {
+    let dir = '';
+    let home = '';
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'tui-mcp-cwd-'));
+        home = mkdtempSync(join(tmpdir(), 'tui-mcp-home-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, {recursive: true, force: true});
+        rmSync(home, {recursive: true, force: true});
+    });
+
+    function run(args: readonly string[]): {
+        status: number | null;
+        stderr: string;
+        stdout: string;
+    } {
+        const result = spawnSync('node', [CLI, 'init', ...args], {
+            cwd: dir,
+            encoding: 'utf8',
+            env: {...process.env, HOME: home, USERPROFILE: home},
+        });
+
+        return {status: result.status, stderr: result.stderr, stdout: result.stdout};
+    }
+
+    it('writes a user-scope cursor config under HOME and not cwd', () => {
+        const {status} = run(['--client', 'cursor', '--scope', 'user']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(home, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+        assert.equal(existsSync(join(dir, '.cursor/mcp.json')), false);
+    });
+
+    it('accepts the -s short flag for user scope', () => {
+        const {status} = run(['--client', 'cursor', '-s', 'user']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(home, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+    });
+
+    it('writes a project-scope cursor config under cwd', () => {
+        const {status} = run(['--client', 'cursor', '--scope', 'project']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+        assert.equal(existsSync(join(home, '.cursor/mcp.json')), false);
+    });
+
+    it('defaults to project scope when --scope is omitted', () => {
+        const {status} = run(['--client', 'cursor']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+        assert.equal(existsSync(join(home, '.cursor/mcp.json')), false);
+    });
+
+    it('exits non-zero for an unknown scope', () => {
+        const {status, stderr} = run(['--client', 'cursor', '--scope', 'bogus']);
+
+        assert.equal(status, 1);
+        assert.match(stderr, /Unknown scope/);
+    });
+
+    it('prints the codex trust note for project scope but not user scope', () => {
+        const project = run(['--client', 'codex', '--scope', 'project']);
+        const user = run(['--client', 'codex', '--scope', 'user']);
+
+        assert.match(project.stdout, /trust this folder in Codex/);
+        assert.doesNotMatch(user.stdout, /trust this folder in Codex/);
     });
 });
 

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -375,6 +375,46 @@ describe('init command --scope (built CLI)', () => {
         assert.match(stdout, /global config/);
         assert.match(stdout, /~\/\.codeium\/windsurf\/mcp_config\.json/);
     });
+
+    it('writes both project and user cursor configs for --scope project,user', () => {
+        const {status} = run(['--client', 'cursor', '--scope', 'project,user']);
+
+        assert.equal(status, 0);
+        assert.ok(readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+        assert.ok(readConfig(join(home, '.cursor/mcp.json')).mcpServers?.['taiga-ui']);
+    });
+
+    it('dedupes windsurf to a single global write for --scope project,user', () => {
+        const {status, stdout} = run(['--client', 'windsurf', '--scope', 'project,user']);
+
+        assert.equal(status, 0);
+        assert.ok(
+            readConfig(join(home, '.codeium/windsurf/mcp_config.json')).mcpServers?.[
+                'taiga-ui'
+            ],
+        );
+        assert.equal(existsSync(join(dir, '.codeium/windsurf/mcp_config.json')), false);
+
+        const summaryLines = stdout.match(
+            /MCP server in ~\/\.codeium\/windsurf\/mcp_config\.json \(Windsurf\)/g,
+        );
+
+        assert.equal(summaryLines?.length, 1);
+    });
+
+    it('prints the codex trust note when scopes include project alongside user', () => {
+        const {status, stdout} = run(['--client', 'codex', '--scope', 'project,user']);
+
+        assert.equal(status, 0);
+        assert.match(stdout, /trust this folder in Codex/);
+    });
+
+    it('exits non-zero when the scope list contains an unknown value', () => {
+        const {status, stderr} = run(['--client', 'cursor', '--scope', 'project,bogus']);
+
+        assert.equal(status, 1);
+        assert.match(stderr, /Unknown scope/);
+    });
 });
 
 describe('resolveSourceUrl', () => {

--- a/test/init.spec.ts
+++ b/test/init.spec.ts
@@ -18,10 +18,10 @@ interface McpConfig {
 function runInit(
     cwd: string,
     args: readonly string[],
-): {status: number | null; stderr: string} {
+): {status: number | null; stderr: string; stdout: string} {
     const result = spawnSync('node', [CLI, 'init', ...args], {cwd, encoding: 'utf8'});
 
-    return {status: result.status, stderr: result.stderr};
+    return {status: result.status, stderr: result.stderr, stdout: result.stdout};
 }
 
 function readConfig(path: string): McpConfig {
@@ -248,6 +248,15 @@ describe('init command (built CLI)', () => {
 
         assert.match(toml, /\[mcp_servers\.other\]/);
         assert.equal(toml.match(/\[mcp_servers\.taiga-ui\]/g)?.length, 1);
+    });
+
+    it('prints a Codex trust note only for codex', () => {
+        const codex = runInit(dir, ['--client', 'codex']);
+        const cursor = runInit(dir, ['--client', 'cursor']);
+
+        assert.match(codex.stdout, /trust this folder in Codex/);
+        assert.match(codex.stdout, /~\/\.codex\/config\.toml/);
+        assert.doesNotMatch(cursor.stdout, /trust/);
     });
 
     it('reflects --version v4 in the codex args', () => {

--- a/test/prompt.spec.ts
+++ b/test/prompt.spec.ts
@@ -8,16 +8,22 @@ import {describe, it} from 'node:test';
 import {fileURLToPath} from 'node:url';
 
 import {
-    parseMenuChoice,
     type PromptIo,
-    promptMenu,
+    promptMultiSelect,
+    promptSelect,
     promptText,
 } from '../src/cli/prompt.js';
 
 const CLI = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+const ESC = String.fromCharCode(27);
+const UP = `${ESC}[A`;
+const DOWN = `${ESC}[B`;
+const ENTER = '\r';
+const SPACE = ' ';
+const ANSI = new RegExp(String.raw`${ESC}\[[0-9;?]*[a-z]`, 'gi');
 
-function fakeIo(line: string): {io: PromptIo; written(): string} {
-    const input = Readable.from(`${line}\n`);
+function keyIo(sequence: string): {io: PromptIo; written(): string} {
+    const input = Readable.from(sequence);
     const chunks: string[] = [];
 
     const output = new Writable({
@@ -31,52 +37,69 @@ function fakeIo(line: string): {io: PromptIo; written(): string} {
         },
     });
 
-    return {io: {input, output}, written: () => chunks.join('')};
+    return {io: {input, output}, written: () => chunks.join('').replaceAll(ANSI, '')};
 }
 
-describe('parseMenuChoice', () => {
-    it('maps a valid number to a 0-based index', () => {
-        assert.equal(parseMenuChoice('1', 3), 0);
-        assert.equal(parseMenuChoice('3', 3), 2);
+describe('promptSelect (arrow keys over injected streams)', () => {
+    it('moves down and selects with enter', {timeout: 5000}, async () => {
+        const {io, written} = keyIo(`${DOWN}${DOWN}${ENTER}`);
+
+        assert.equal(await promptSelect('Pick', ['a', 'b', 'c'], 0, io), 2);
+
+        const text = written();
+
+        assert.ok(text.includes('a') && text.includes('b') && text.includes('c'));
     });
 
-    it('returns the default on empty input', () => {
-        assert.equal(parseMenuChoice('', 3, 0), 0);
-        assert.equal(parseMenuChoice('  ', 3, 1), 1);
+    it('wraps around when moving up from the first item', {timeout: 5000}, async () => {
+        const {io} = keyIo(`${UP}${ENTER}`);
+
+        assert.equal(await promptSelect('Pick', ['a', 'b', 'c'], 0, io), 2);
     });
 
-    it('returns null for empty input without a default', () => {
-        assert.equal(parseMenuChoice('', 3), null);
-    });
+    it('honors the initial index', {timeout: 5000}, async () => {
+        const {io} = keyIo(ENTER);
 
-    it('returns null for out-of-range or non-numeric input', () => {
-        assert.equal(parseMenuChoice('0', 3), null);
-        assert.equal(parseMenuChoice('4', 3), null);
-        assert.equal(parseMenuChoice('x', 3), null);
-        assert.equal(parseMenuChoice('1.5', 3), null);
+        assert.equal(await promptSelect('Pick', ['a', 'b', 'c'], 1, io), 1);
     });
 });
 
-describe('promptMenu (real readline over injected streams)', () => {
-    it('resolves to the selected index and renders the menu', async () => {
-        const {io, written} = fakeIo('2');
+describe('promptMultiSelect (space toggles, enter confirms)', () => {
+    it('returns every toggled index in order', {timeout: 5000}, async () => {
+        const {io} = keyIo(`${SPACE}${DOWN}${DOWN}${SPACE}${ENTER}`);
 
-        assert.equal(await promptMenu('Pick', ['a', 'b', 'c'], undefined, io), 1);
-        assert.match(written(), /1\) a[\s\S]*2\) b[\s\S]*3\) c/);
+        assert.deepEqual(await promptMultiSelect('Pick', ['a', 'b', 'c'], io), [0, 2]);
     });
 
-    it('returns the default index on empty input', async () => {
-        const {io} = fakeIo('');
+    it(
+        'falls back to the highlighted row when nothing is toggled',
+        {timeout: 5000},
+        async () => {
+            const {io} = keyIo(`${DOWN}${ENTER}`);
 
-        assert.equal(await promptMenu('Pick', ['a', 'b'], 0, io), 0);
+            assert.deepEqual(await promptMultiSelect('Pick', ['a', 'b', 'c'], io), [1]);
+        },
+    );
+
+    it('renders a checkbox for each row', {timeout: 5000}, async () => {
+        const {io, written} = keyIo(ENTER);
+
+        await promptMultiSelect('Pick', ['a', 'b'], io);
+        assert.ok(written().includes('[ ] a'));
     });
 });
 
 describe('promptText (real readline over injected streams)', () => {
-    it('reads and trims a line', async () => {
-        const {io} = fakeIo('  v4  ');
+    it('reads and trims a line', {timeout: 5000}, async () => {
+        const input = Readable.from('  v4  \n');
 
-        assert.equal(await promptText('Major?', io), 'v4');
+        const output = new Writable({
+            write(_chunk, _encoding, callback): void {
+                callback();
+            },
+        });
+
+        assert.equal(await promptText('Major?', {input, output}), 'v4');
     });
 });
 

--- a/test/prompt.spec.ts
+++ b/test/prompt.spec.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {Readable, Writable} from 'node:stream';
+import {describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+import {
+    parseMenuChoice,
+    type PromptIo,
+    promptMenu,
+    promptText,
+} from '../src/cli/prompt.js';
+
+const CLI = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+
+function fakeIo(line: string): {io: PromptIo; written(): string} {
+    const input = Readable.from(`${line}\n`);
+    const chunks: string[] = [];
+
+    const output = new Writable({
+        write(
+            chunk: Buffer | string,
+            _encoding: BufferEncoding,
+            callback: (error?: Error | null) => void,
+        ): void {
+            chunks.push(chunk.toString());
+            callback();
+        },
+    });
+
+    return {io: {input, output}, written: () => chunks.join('')};
+}
+
+describe('parseMenuChoice', () => {
+    it('maps a valid number to a 0-based index', () => {
+        assert.equal(parseMenuChoice('1', 3), 0);
+        assert.equal(parseMenuChoice('3', 3), 2);
+    });
+
+    it('returns the default on empty input', () => {
+        assert.equal(parseMenuChoice('', 3, 0), 0);
+        assert.equal(parseMenuChoice('  ', 3, 1), 1);
+    });
+
+    it('returns null for empty input without a default', () => {
+        assert.equal(parseMenuChoice('', 3), null);
+    });
+
+    it('returns null for out-of-range or non-numeric input', () => {
+        assert.equal(parseMenuChoice('0', 3), null);
+        assert.equal(parseMenuChoice('4', 3), null);
+        assert.equal(parseMenuChoice('x', 3), null);
+        assert.equal(parseMenuChoice('1.5', 3), null);
+    });
+});
+
+describe('promptMenu (real readline over injected streams)', () => {
+    it('resolves to the selected index and renders the menu', async () => {
+        const {io, written} = fakeIo('2');
+
+        assert.equal(await promptMenu('Pick', ['a', 'b', 'c'], undefined, io), 1);
+        assert.match(written(), /1\) a[\s\S]*2\) b[\s\S]*3\) c/);
+    });
+
+    it('returns the default index on empty input', async () => {
+        const {io} = fakeIo('');
+
+        assert.equal(await promptMenu('Pick', ['a', 'b'], 0, io), 0);
+    });
+});
+
+describe('promptText (real readline over injected streams)', () => {
+    it('reads and trims a line', async () => {
+        const {io} = fakeIo('  v4  ');
+
+        assert.equal(await promptText('Major?', io), 'v4');
+    });
+});
+
+describe('non-interactive init (no TTY)', () => {
+    it('exits with the missing-client error instead of prompting', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tui-mcp-'));
+
+        try {
+            const result = spawnSync('node', [CLI, 'init'], {
+                cwd: dir,
+                encoding: 'utf8',
+                timeout: 10000,
+            });
+
+            assert.equal(result.status, 1);
+            assert.match(result.stderr, /Missing --client/);
+        } finally {
+            rmSync(dir, {recursive: true, force: true});
+        }
+    });
+});

--- a/test/remove.spec.ts
+++ b/test/remove.spec.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+const CLI = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+
+interface McpConfig {
+    readonly mcpServers?: Record<string, {command: string; args: string[]}>;
+}
+
+interface Run {
+    readonly status: number | null;
+    readonly stderr: string;
+    readonly stdout: string;
+}
+
+function run(cwd: string, command: string, args: readonly string[], home?: string): Run {
+    const env = home ? {...process.env, HOME: home, USERPROFILE: home} : process.env;
+
+    const result = spawnSync('node', [CLI, command, ...args], {
+        cwd,
+        encoding: 'utf8',
+        env,
+    });
+
+    return {status: result.status, stderr: result.stderr, stdout: result.stdout};
+}
+
+function readConfig(path: string): McpConfig {
+    return JSON.parse(readFileSync(path, 'utf8')) as McpConfig;
+}
+
+function readText(path: string): string {
+    return readFileSync(path, 'utf8');
+}
+
+describe('remove command (built CLI)', () => {
+    let dir = '';
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'tui-mcp-rm-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, {recursive: true, force: true});
+    });
+
+    it('round-trips a JSON client, stripping ours and keeping others (cursor)', () => {
+        mkdirSync(join(dir, '.cursor'));
+        writeFileSync(
+            join(dir, '.cursor/mcp.json'),
+            '{"mcpServers":{"other":{"command":"x","args":[]}}}',
+        );
+
+        run(dir, 'init', ['--client', 'cursor']);
+        const removed = run(dir, 'remove', ['--client', 'cursor']);
+
+        assert.equal(removed.status, 0);
+        assert.match(removed.stdout, /Removed "taiga-ui" from \.cursor\/mcp\.json/);
+
+        const config = readConfig(join(dir, '.cursor/mcp.json'));
+
+        assert.ok(config.mcpServers?.other);
+        assert.equal(config.mcpServers['taiga-ui'], undefined);
+    });
+
+    it('round-trips the TOML client, stripping ours and keeping others (codex)', () => {
+        mkdirSync(join(dir, '.codex'));
+        writeFileSync(
+            join(dir, '.codex/config.toml'),
+            '[mcp_servers.other]\ncommand = "y"\nargs = []\n',
+        );
+
+        run(dir, 'init', ['--client', 'codex']);
+        const removed = run(dir, 'remove', ['--client', 'codex']);
+
+        assert.equal(removed.status, 0);
+        assert.match(removed.stdout, /Removed "taiga-ui"/);
+
+        const toml = readText(join(dir, '.codex/config.toml'));
+
+        assert.match(toml, /\[mcp_servers\.other\]/);
+        assert.doesNotMatch(toml, /\[mcp_servers\.taiga-ui\]/);
+    });
+
+    it('is a graceful no-op when our entry is absent', () => {
+        const removed = run(dir, 'remove', ['--client', 'cursor']);
+
+        assert.equal(removed.status, 0);
+        assert.match(removed.stdout, /No "taiga-ui" server in \.cursor\/mcp\.json/);
+    });
+
+    it('exits non-zero and lists clients for an unknown client', () => {
+        const {status, stderr} = run(dir, 'remove', ['--client', 'foo']);
+
+        assert.equal(status, 1);
+        assert.match(stderr, /Unknown client/);
+    });
+});
+
+describe('remove command --scope (built CLI)', () => {
+    let dir = '';
+    let home = '';
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'tui-mcp-rm-cwd-'));
+        home = mkdtempSync(join(tmpdir(), 'tui-mcp-rm-home-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, {recursive: true, force: true});
+        rmSync(home, {recursive: true, force: true});
+    });
+
+    it('removes a user-scope entry under HOME', () => {
+        run(dir, 'init', ['--client', 'cursor', '--scope', 'user'], home);
+        const removed = run(
+            dir,
+            'remove',
+            ['--client', 'cursor', '--scope', 'user'],
+            home,
+        );
+
+        assert.equal(removed.status, 0);
+        assert.match(removed.stdout, /Removed "taiga-ui" from ~\/\.cursor\/mcp\.json/);
+        assert.equal(
+            readConfig(join(home, '.cursor/mcp.json')).mcpServers?.['taiga-ui'],
+            undefined,
+        );
+    });
+
+    it('removes windsurf from the global config even for project scope', () => {
+        run(dir, 'init', ['--client', 'windsurf'], home);
+        const removed = run(dir, 'remove', ['--client', 'windsurf'], home);
+
+        assert.equal(removed.status, 0);
+        assert.match(removed.stdout, /Removed "taiga-ui"/);
+        assert.equal(
+            readConfig(join(home, '.codeium/windsurf/mcp_config.json')).mcpServers?.[
+                'taiga-ui'
+            ],
+            undefined,
+        );
+    });
+});

--- a/test/remove.spec.ts
+++ b/test/remove.spec.ts
@@ -133,6 +133,26 @@ describe('remove command --scope (built CLI)', () => {
         );
     });
 
+    it('removes both project and user cursor configs for --scope project,user', () => {
+        run(dir, 'init', ['--client', 'cursor', '--scope', 'project,user'], home);
+        const removed = run(
+            dir,
+            'remove',
+            ['--client', 'cursor', '--scope', 'project,user'],
+            home,
+        );
+
+        assert.equal(removed.status, 0);
+        assert.equal(
+            readConfig(join(dir, '.cursor/mcp.json')).mcpServers?.['taiga-ui'],
+            undefined,
+        );
+        assert.equal(
+            readConfig(join(home, '.cursor/mcp.json')).mcpServers?.['taiga-ui'],
+            undefined,
+        );
+    });
+
     it('removes windsurf from the global config even for project scope', () => {
         run(dir, 'init', ['--client', 'windsurf'], home);
         const removed = run(dir, 'remove', ['--client', 'windsurf'], home);

--- a/test/scope.spec.ts
+++ b/test/scope.spec.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import {join} from 'node:path';
+import {describe, it} from 'node:test';
+
+import {type ClientConfig, findClient} from '../src/cli/clients.js';
+import {displayPath, resolveConfigPath, type ScopeEnv} from '../src/cli/scope.js';
+
+const CWD = '/work/project';
+const HOME = '/home/user';
+
+function client(id: string): ClientConfig {
+    const found = findClient(id);
+
+    assert.ok(found, `missing client ${id}`);
+
+    return found;
+}
+
+function env(platform: NodeJS.Platform): ScopeEnv {
+    return {cwd: CWD, home: HOME, platform};
+}
+
+describe('resolveConfigPath', () => {
+    it('joins the project path under cwd regardless of scope target', () => {
+        assert.equal(
+            resolveConfigPath(client('cursor'), 'project', env('linux')),
+            join(CWD, '.cursor/mcp.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('codex'), 'project', env('darwin')),
+            join(CWD, '.codex/config.toml'),
+        );
+    });
+
+    it('joins a simple user path under home', () => {
+        assert.equal(
+            resolveConfigPath(client('claude'), 'user', env('linux')),
+            join(HOME, '.claude.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('cursor'), 'user', env('darwin')),
+            join(HOME, '.cursor/mcp.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('opencode'), 'user', env('win32')),
+            join(HOME, '.config/opencode/opencode.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('codex'), 'user', env('linux')),
+            join(HOME, '.codex/config.toml'),
+        );
+    });
+
+    it('picks the per-platform user path for vscode', () => {
+        assert.equal(
+            resolveConfigPath(client('vscode'), 'user', env('darwin')),
+            join(HOME, 'Library/Application Support/Code/User/mcp.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('vscode'), 'user', env('win32')),
+            join(HOME, 'AppData/Roaming/Code/User/mcp.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('vscode'), 'user', env('linux')),
+            join(HOME, '.config/Code/User/mcp.json'),
+        );
+    });
+
+    it('falls back to the linux path on unlisted platforms', () => {
+        assert.equal(
+            resolveConfigPath(client('vscode'), 'user', env('aix')),
+            join(HOME, '.config/Code/User/mcp.json'),
+        );
+        assert.equal(
+            resolveConfigPath(client('vscode'), 'user', env('freebsd')),
+            join(HOME, '.config/Code/User/mcp.json'),
+        );
+    });
+});
+
+describe('displayPath', () => {
+    it('shows the relative project path for project scope', () => {
+        assert.equal(
+            displayPath(client('cursor'), 'project', env('linux')),
+            '.cursor/mcp.json',
+        );
+        assert.equal(
+            displayPath(client('vscode'), 'project', env('darwin')),
+            '.vscode/mcp.json',
+        );
+    });
+
+    it('shows a ~/ prefixed path for user scope', () => {
+        assert.equal(
+            displayPath(client('cursor'), 'user', env('linux')),
+            '~/.cursor/mcp.json',
+        );
+        assert.equal(
+            displayPath(client('claude'), 'user', env('linux')),
+            '~/.claude.json',
+        );
+        assert.equal(
+            displayPath(client('codex'), 'user', env('linux')),
+            '~/.codex/config.toml',
+        );
+    });
+
+    it('shows the per-platform user path for vscode', () => {
+        assert.equal(
+            displayPath(client('vscode'), 'user', env('darwin')),
+            '~/Library/Application Support/Code/User/mcp.json',
+        );
+        assert.equal(
+            displayPath(client('vscode'), 'user', env('win32')),
+            '~/AppData/Roaming/Code/User/mcp.json',
+        );
+        assert.equal(
+            displayPath(client('vscode'), 'user', env('aix')),
+            '~/.config/Code/User/mcp.json',
+        );
+    });
+});

--- a/test/toml-file.spec.ts
+++ b/test/toml-file.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
 
-import {buildTomlTable, upsertTomlTable} from '../src/cli/toml-file.js';
+import {buildTomlTable, removeTomlTable, upsertTomlTable} from '../src/cli/toml-file.js';
 
 const TABLE = 'mcp_servers.taiga-ui';
 
@@ -101,5 +101,71 @@ describe('upsertTomlTable', () => {
         assert.match(content, /command = "y"/);
         assert.doesNotMatch(content, /OLD/);
         assert.equal(content.match(/\[mcp_servers\.taiga-ui\]/g)?.length, 1);
+    });
+});
+
+describe('removeTomlTable', () => {
+    it('removes ours and keeps a preceding table, trimming its body', () => {
+        const existing = [
+            '[mcp_servers.other]',
+            'command = "y"',
+            'args = []',
+            '',
+            '[mcp_servers.taiga-ui]',
+            'command = "npx"',
+            'args = ["-y"]',
+            '',
+        ].join('\n');
+
+        const {content, removed} = removeTomlTable(existing, TABLE);
+
+        assert.equal(removed, true);
+        assert.equal(
+            content,
+            ['[mcp_servers.other]', 'command = "y"', 'args = []', ''].join('\n'),
+        );
+    });
+
+    it('removes ours when it comes first, keeping the following table', () => {
+        const existing = [
+            '[mcp_servers.taiga-ui]',
+            'command = "npx"',
+            'args = ["-y"]',
+            '',
+            '[mcp_servers.other]',
+            'command = "y"',
+            'args = []',
+            '',
+        ].join('\n');
+
+        const {content, removed} = removeTomlTable(existing, TABLE);
+
+        assert.equal(removed, true);
+        assert.equal(
+            content,
+            ['[mcp_servers.other]', 'command = "y"', 'args = []', ''].join('\n'),
+        );
+    });
+
+    it('empties the file when ours is the only table', () => {
+        const existing = [
+            '[mcp_servers.taiga-ui]',
+            'command = "npx"',
+            'args = ["-y"]',
+            '',
+        ].join('\n');
+
+        const {content, removed} = removeTomlTable(existing, TABLE);
+
+        assert.equal(removed, true);
+        assert.equal(content, '');
+    });
+
+    it('reports removed=false and leaves content untouched when absent', () => {
+        const existing = '[mcp_servers.other]\ncommand = "y"\nargs = []\n';
+        const {content, removed} = removeTomlTable(existing, TABLE);
+
+        assert.equal(removed, false);
+        assert.equal(content, existing);
     });
 });

--- a/test/toml-file.spec.ts
+++ b/test/toml-file.spec.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {buildTomlTable, upsertTomlTable} from '../src/cli/toml-file.js';
+
+const TABLE = 'mcp_servers.taiga-ui';
+
+const ENTRY = {
+    command: 'npx',
+    args: ['-y', '@taiga-ui/mcp@latest', '--source-url=URL'],
+} as const;
+
+describe('buildTomlTable', () => {
+    it('emits a header, command, and args with valid quoting', () => {
+        assert.equal(
+            buildTomlTable(TABLE, ENTRY),
+            [
+                '[mcp_servers.taiga-ui]',
+                'command = "npx"',
+                'args = ["-y", "@taiga-ui/mcp@latest", "--source-url=URL"]',
+            ].join('\n'),
+        );
+    });
+
+    it('escapes quotes inside strings via JSON string rules', () => {
+        const table = buildTomlTable(TABLE, {command: 'a"b', args: ['c=d']});
+
+        assert.match(table, /command = "a\\"b"/);
+        assert.match(table, /args = \["c=d"\]/);
+    });
+});
+
+describe('upsertTomlTable', () => {
+    it('creates the table for missing/blank content', () => {
+        const {content, existed} = upsertTomlTable('', TABLE, ENTRY);
+
+        assert.equal(existed, false);
+        assert.equal(
+            content,
+            [
+                '[mcp_servers.taiga-ui]',
+                'command = "npx"',
+                'args = ["-y", "@taiga-ui/mcp@latest", "--source-url=URL"]',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('appends after existing content, preserving it', () => {
+        const existing = '[mcp_servers.other]\ncommand = "y"\nargs = []\n';
+        const {content, existed} = upsertTomlTable(existing, TABLE, ENTRY);
+
+        assert.equal(existed, false);
+        assert.equal(
+            content,
+            [
+                '[mcp_servers.other]',
+                'command = "y"',
+                'args = []',
+                '',
+                '[mcp_servers.taiga-ui]',
+                'command = "npx"',
+                'args = ["-y", "@taiga-ui/mcp@latest", "--source-url=URL"]',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('replaces the table in place without duplicating the header', () => {
+        const existing = [
+            '[mcp_servers.taiga-ui]',
+            'command = "npx"',
+            'args = ["-y", "@taiga-ui/mcp@latest", "--source-url=OLD"]',
+            '',
+        ].join('\n');
+
+        const {content, existed} = upsertTomlTable(existing, TABLE, ENTRY);
+
+        assert.equal(existed, true);
+        assert.equal(content.match(/\[mcp_servers\.taiga-ui\]/g)?.length, 1);
+        assert.match(content, /--source-url=URL/);
+        assert.doesNotMatch(content, /OLD/);
+    });
+
+    it('replaces in place while keeping tables that follow', () => {
+        const existing = [
+            '[mcp_servers.taiga-ui]',
+            'command = "npx"',
+            'args = ["-y", "--source-url=OLD"]',
+            '',
+            '[mcp_servers.other]',
+            'command = "y"',
+            'args = []',
+            '',
+        ].join('\n');
+
+        const {content, existed} = upsertTomlTable(existing, TABLE, ENTRY);
+
+        assert.equal(existed, true);
+        assert.match(content, /\[mcp_servers\.other\]/);
+        assert.match(content, /command = "y"/);
+        assert.doesNotMatch(content, /OLD/);
+        assert.equal(content.match(/\[mcp_servers\.taiga-ui\]/g)?.length, 1);
+    });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "@taiga-ui/tsconfig",
     "compilerOptions": {
         "baseUrl": "./",
-        "rootDir": "./src",
         "checkJs": false,
         "esModuleInterop": true,
         "module": "NodeNext",
@@ -12,6 +11,6 @@
         "typeRoots": ["node_modules/@types", "node_modules/@taiga-ui/tsconfig"],
         "types": ["node"]
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "test/**/*"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes https://github.com/taiga-family/taiga-ui-mcp/issues/3

Adds two CLI commands to `@taiga-ui/mcp` for wiring the `taiga-ui` MCP server into a client's config, plus the repo's first test suite. Running with no subcommand still starts the stdio MCP server exactly as before.

Init:
<img width="1483" height="561" alt="image" src="https://github.com/user-attachments/assets/d8dc7569-b8a8-4dfa-84e3-0c201be074ff" />

Remove:
<img width="798" height="390" alt="image" src="https://github.com/user-attachments/assets/83c978d5-4dd4-4d23-89ec-07c72bce37ae" />



## Commands

**`init`** — scaffolds the `taiga-ui` server into a client config (creates the file or merges into it).

- `--client <id>` — one or more clients; comma-separated (`--client cursor,codex`) and/or repeated.
- `--version latest|next|vN` — docs channel (default `latest`); `--source-url <url>` for a full override.
- `--scope project|user` (`-s`, default `project`) — project-local file vs. machine-global.
- No flags in a terminal → interactive picker (multi-select clients, single-select version and scope). Non-TTY never prompts, so `npx` never hangs in CI.

**`remove`** — strips the `taiga-ui` server from a client config, leaving other servers untouched; graceful no-op with a message when nothing is present. Same `--client` / `--scope` flags and pickers.

## Supported clients

| Client | Project file | Format |
| --- | --- | --- |
| Claude Code | `.mcp.json` | JSON |
| Cursor | `.cursor/mcp.json` | JSON |
| VS Code | `.vscode/mcp.json` | JSON (stdio entry) |
| OpenCode | `opencode.json` | JSON |
| Codex | `.codex/config.toml` | TOML |
| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON (global only) |

Windsurf only reads a machine-global config, so it's always written there regardless of `--scope`. Codex prints a trusted-workspace note for project scope.

## Notes

- **Non-destructive**: JSON deep-merge preserves other servers and unrelated keys; TOML table upsert; an existing invalid config is never clobbered.
- **Dependency-free**: no new runtime deps (still just the MCP SDK + zod).
- **Tests / CI**: first test setup for the repo — `node:test` via `tsx` (~80 tests), wired as `npm test` and a CI `Test` job.
- README documents every command and flag.
