### PR TITLE
docs: describe interactive init and v5 (latest) / v4 version choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,16 @@ development workflow.
 
 First, install the Taiga UI MCP server with your client.
 
-**Standard config** works in most of the tools:
-
-```json
-{
-  "mcpServers": {
-    "taiga-ui": {
-      "command": "npx",
-      "args": [
-        "@taiga-ui/mcp@latest",
-        "--source-url=https://taiga-ui.dev/llms-full.txt" // or the /v4 version, if you want
-      ]
-    }
-  }
-}
-```
-
 #### Quick install
 
-Prefer a one-liner? Run `init` to write (or merge) the config into your client's project-local file:
+The fastest way is the interactive `init` command. Run it with no flags to pick the client, the docs version
+(`v5 (latest)` or `v4`), and the scope:
+
+```bash
+npx @taiga-ui/mcp init
+```
+
+Prefer a one-liner? `init` writes (or merges) the config into your client's project-local file:
 
 ```bash
 npx @taiga-ui/mcp init --client claude # writes .mcp.json
@@ -75,8 +66,23 @@ npx @taiga-ui/mcp init --client cursor --scope user # writes ~/.cursor/mcp.json
 npx @taiga-ui/mcp init --client cursor --scope project,user # writes both .cursor/mcp.json and ~/.cursor/mcp.json
 ```
 
-Or run `npx @taiga-ui/mcp init` with no flags to pick everything interactively — the client, the docs version
-(`v5 (latest)` or `v4`), and the scope.
+#### Standard config
+
+Prefer manual setup? The standard config works in most of the tools:
+
+```json
+{
+  "mcpServers": {
+    "taiga-ui": {
+      "command": "npx",
+      "args": [
+        "@taiga-ui/mcp@latest",
+        "--source-url=https://taiga-ui.dev/llms-full.txt" // or the /v4 version, if you want
+      ]
+    }
+  }
+}
+```
 
 #### Removing the server
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ development workflow.
 - **Docs + code snippets**. Full Taiga UI markdown plus ready Angular examples in one place.
 - **Four MCP tools**. Get structured overview with `get_overview`, discover with `get_list_components`, fetch examples
   via `get_component_example`, and access migration guides with `get_migration_guide`.
-- **Configurable & lightweight**. Swap source URL (stable/next) without local Angular install.
+- **Configurable & lightweight**. Pick the docs version (`v5 (latest)` or `v4`) without a local Angular install.
 
 ### Requirements
 
@@ -34,7 +34,7 @@ First, install the Taiga UI MCP server with your client.
       "command": "npx",
       "args": [
         "@taiga-ui/mcp@latest",
-        "--source-url=https://taiga-ui.dev/llms-full.txt" // or file from /next version, if you want
+        "--source-url=https://taiga-ui.dev/llms-full.txt" // or the /v4 version, if you want
       ]
     }
   }
@@ -57,10 +57,10 @@ npx @taiga-ui/mcp init --client codex # writes .codex/config.toml
 Windsurf only reads a machine-global MCP config, so `--client windsurf` always writes
 `~/.codeium/windsurf/mcp_config.json` regardless of `--scope`.
 
-Target another docs version with `--version` — `next`, or a previous major like `v4` (defaults to `latest`):
+Pick the docs version with `--version` — `latest` (v5), or a previous major like `v4` (defaults to `latest`):
 
 ```bash
-npx @taiga-ui/mcp init --client cursor --version next
+npx @taiga-ui/mcp init --client cursor --version latest
 npx @taiga-ui/mcp init --client cursor --version v4
 ```
 
@@ -75,7 +75,8 @@ npx @taiga-ui/mcp init --client cursor --scope user # writes ~/.cursor/mcp.json
 npx @taiga-ui/mcp init --client cursor --scope project,user # writes both .cursor/mcp.json and ~/.cursor/mcp.json
 ```
 
-Or just run `npx @taiga-ui/mcp init` with no flags to pick the client, docs version, and scope interactively.
+Or run `npx @taiga-ui/mcp init` with no flags to pick everything interactively — the client, the docs version
+(`v5 (latest)` or `v4`), and the scope.
 
 #### Removing the server
 


### PR DESCRIPTION
Updates the README to reflect the interactive `init` flow and the actual docs version choices (`v5 (latest)` / `v4`) instead of the stale `latest/next/other` wording.

- Key features bullet now mentions picking the docs version `v5 (latest)` or `v4`
- Standard config comment points to `/v4` instead of `/next`
- `--version` section shows `latest` (v5) / `v4`
- Interactive no-flags command now names the `v5 (latest)` / `v4` picker